### PR TITLE
Fix QRCode readability

### DIFF
--- a/src/app/containers/FastBtcForm/index.tsx
+++ b/src/app/containers/FastBtcForm/index.tsx
@@ -107,9 +107,11 @@ export function FastBtcForm(props: Props) {
                       <QRCode
                         value={state.depositAddress}
                         renderAs="svg"
-                        bgColor="var(--primary)"
-                        fgColor="var(--white)"
+                        bgColor="var(--white)"
+                        fgColor="var(--primary)"
+                        includeMargin={true}
                         size={258}
+                        className="rounded"
                       />
                     </div>
                     <div className="d-flex flex-row justify-content-center mt-3">


### PR DESCRIPTION
The problem wasn't in the QR resolution, size, or encoding. The problem was with the color. Had to revert the colors and add a margin.

![image](https://user-images.githubusercontent.com/25356559/99977055-7c67dc80-2da4-11eb-9807-7107141afe50.png)
