### PR TITLE
Changed node-sass to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "mathjs": "7.1.0",
     "mini-css-extract-plugin": "0.9.0",
     "node-plop": "0.25.0",
-    "node-sass": "4.14.1",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "plop": "2.6.0",
     "pnp-webpack-plugin": "1.6.4",
@@ -268,6 +267,7 @@
     "@sentry/webpack-plugin": "1.13.0",
     "@types/mathjs": "6.0.5",
     "@types/socket.io-client": "1.4.34",
+    "node-sass": "4.14.1",
     "webpack-subresource-integrity": "1.5.2"
   },
   "babel": {


### PR DESCRIPTION
The buddy pipeline checks failed with the previous PR because the bundle size was too large. I think this might be because I had node-sass installed as a dependency instead of a devDependency - I've change that so hopefully it will be fixed