### PR TITLE
Fixes #92 lend/borrow tabs for pt_br on mobile screen

### DIFF
--- a/src/app/components/LanguageToggle/index.tsx
+++ b/src/app/components/LanguageToggle/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import i18next from 'i18next';
 import { reactLocalStorage } from 'reactjs-localstorage';
@@ -8,17 +8,9 @@ export function LanguageToggle() {
     i18next.language || reactLocalStorage.get('i18nextLng'),
   );
 
-  useEffect(() => {
-    document.documentElement.setAttribute(
-      'lang',
-      i18next.language || reactLocalStorage.get('i18nextLng'),
-    );
-  }, []);
-
   const changeLanguage = lng => {
     i18next.changeLanguage(lng);
     reactLocalStorage.set('i18nextLng', lng);
-    document.documentElement.setAttribute('lang', lng);
     setCurrentLang(lng);
   };
 

--- a/src/app/components/LanguageToggle/index.tsx
+++ b/src/app/components/LanguageToggle/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+
 import i18next from 'i18next';
 import { reactLocalStorage } from 'reactjs-localstorage';
 
@@ -7,9 +8,17 @@ export function LanguageToggle() {
     i18next.language || reactLocalStorage.get('i18nextLng'),
   );
 
+  useEffect(() => {
+    document.documentElement.setAttribute(
+      'lang',
+      i18next.language || reactLocalStorage.get('i18nextLng'),
+    );
+  }, []);
+
   const changeLanguage = lng => {
     i18next.changeLanguage(lng);
     reactLocalStorage.set('i18nextLng', lng);
+    document.documentElement.setAttribute('lang', lng);
     setCurrentLang(lng);
   };
 

--- a/src/styles/sass/new-design.scss
+++ b/src/styles/sass/new-design.scss
@@ -37,6 +37,11 @@
 
   .nav-tabs {
     border-bottom: 0;
+    & a[id*="borrow-&-lend-tabs-tab-lend"], a[id*="borrow-&-lend-tabs-tab-borrow"] {
+      &:lang(pt_br) {
+        font-size: 12px;
+      }
+    }
     & .nav-item {
       font-size: 15px;
       color: $text-muted;

--- a/src/styles/sass/new-design.scss
+++ b/src/styles/sass/new-design.scss
@@ -37,11 +37,7 @@
 
   .nav-tabs {
     border-bottom: 0;
-    & a[id*="borrow-&-lend-tabs-tab-lend"], a[id*="borrow-&-lend-tabs-tab-borrow"] {
-      &:lang(pt_br) {
-        font-size: 12px;
-      }
-    }
+    flex-wrap: nowrap;
     & .nav-item {
       font-size: 15px;
       color: $text-muted;
@@ -64,6 +60,13 @@
         color: $white;
         border-color: $white;
         border-bottom: 1px solid $dark;
+      }
+      &:not(.active) {
+        flex: 1;
+        max-width: fit-content;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
     }
   }


### PR DESCRIPTION
Updates html lang attribute when updating language in the footer so that the styling can know whether it should style a little bit differently based on the language it is in.  It makes the font size a little bit smaller so that the tabs fit in one row since there is more text for that language.