### PR TITLE
Add translation strings for #143

### DIFF
--- a/src/app/components/MetaMaskDiscouragementNotifyModal/index.tsx
+++ b/src/app/components/MetaMaskDiscouragementNotifyModal/index.tsx
@@ -4,7 +4,10 @@
  *
  */
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { translations } from '../../../locales/i18n';
 import { Checkbox } from '@blueprintjs/core';
+import styled from 'styled-components/macro';
 import { local } from '../../../utils/storage';
 import { Dialog } from '../../containers/Dialog/Loadable';
 import logo from './logo.svg';
@@ -19,6 +22,7 @@ const testForMetaMask = () => {
 };
 
 export function MetaMaskDiscouragementNotifyModal(props: Props) {
+  const { t } = useTranslation();
   const [show, setShow] = useState(!local.getItem(SESSION_KEY));
   const [checked, setChecked] = useState(false);
 
@@ -46,7 +50,7 @@ export function MetaMaskDiscouragementNotifyModal(props: Props) {
           className="font-weight-bold text-center mb-4"
           style={{ fontSize: '25px' }}
         >
-          Caution… No Really
+          {t(translations.notifyDialog.heading)}
         </div>
         {testForMetaMask() ? <MetaMaskAlert /> : <GeneralAlert />}
       </div>
@@ -55,11 +59,11 @@ export function MetaMaskDiscouragementNotifyModal(props: Props) {
         <Checkbox
           checked={checked}
           onChange={() => setChecked(!checked)}
-          label="I have read and understand that I am responsible for my own Sovrynity"
+          label={t(translations.notifyDialog.acceptTerms)}
         />
         <div className="mt-4">
           <SalesButton
-            text="I Understand"
+            text={t(translations.notifyDialog.salesBtn)}
             onClick={handleClose}
             disabled={!checked}
           />
@@ -70,44 +74,38 @@ export function MetaMaskDiscouragementNotifyModal(props: Props) {
 }
 
 function GeneralAlert() {
+  const { t } = useTranslation();
   return (
     <>
       <p className="font-weight-bold">
-        SOVRYN is a decentralized bitcoin trading and lending platform, the
-        first of it kind!
+        {t(translations.notifyDialog.generalAlert.p1)}
       </p>
       <div className="px-3 text-left">
+        <p>{t(translations.notifyDialog.generalAlert.p2)}</p>
+        <p>{t(translations.notifyDialog.generalAlert.p3)}</p>
         <p>
-          Only you control and have access to your wealth, any actions you take
-          could cause a potential loss of funds.
-        </p>
-        <p>
-          Make sure to check all transaction fee prices before proceeding as
-          third party wallets may automatically present high fees.
-        </p>
-        <p>
-          Please visit our{' '}
+          {t(translations.notifyDialog.generalAlert.p4_1)}
           <a
             href="https://sovryn-1.gitbook.io/sovryn/"
             className="font-weight-light text-gold"
             target="_blank"
             rel="noreferrer noopener"
           >
-            FAQ
-          </a>{' '}
-          if you have any questions.
+            {t(translations.notifyDialog.generalAlert.p4_2)}
+          </a>
+          {t(translations.notifyDialog.generalAlert.p4_3)}
         </p>
         <p>
-          If you’re new to DeFi, here is the{' '}
+          {t(translations.notifyDialog.generalAlert.p5_1)}
           <a
             href="https://sovryn-1.gitbook.io/sovryn/"
             className="font-weight-light text-gold"
             target="_blank"
             rel="noreferrer noopener"
           >
-            tutorial
-          </a>{' '}
-          on how to use SOVRYN.
+            {t(translations.notifyDialog.generalAlert.p5_2)}
+          </a>
+          {t(translations.notifyDialog.generalAlert.p5_3)}
         </p>
       </div>
     </>
@@ -115,54 +113,84 @@ function GeneralAlert() {
 }
 
 function MetaMaskAlert() {
+  const { t } = useTranslation();
+
+  const StyledList = styled.ul`
+    padding-inline-start: 0px; //reset default browser list style
+    margin-left: 1rem;
+  `;
+
   return (
     <>
       <p className="font-weight-bold">
-        We noticed you have MetaMask installed.
+        {t(translations.notifyDialog.metamaskAlert.p1)}
       </p>
       <div className="px-3 text-left">
         <p>
-          There are known issues when using MetaMask with SOVRYN. We suggest
-          using a browser wallet like{' '}
+          {t(translations.notifyDialog.metamaskAlert.p2_1)}
           <a
             href="https://chrome.google.com/webstore/detail/liquality-wallet/kpfopkelmapcoipemfendmdcghnegimn"
             className="font-weight-light text-gold"
             target="_blank"
             rel="noreferrer noopener"
           >
-            Liquality Wallet
-          </a>{' '}
-          or{' '}
+            {t(translations.notifyDialog.metamaskAlert.p2_2)}
+          </a>
+          {t(translations.notifyDialog.metamaskAlert.p2_3)}
           <a
             href="https://chrome.google.com/webstore/detail/nifty-wallet/jbdaocneiiinmjbjlgalhcelgbejmnid"
             className="font-weight-light text-gold"
             target="_blank"
             rel="noreferrer noopener"
           >
-            Nifty Wallet
+            {t(translations.notifyDialog.metamaskAlert.p2_4)}
           </a>
-          . If you wish to continue with MetaMask please be aware of the
-          following know errors:
+          {t(translations.notifyDialog.metamaskAlert.p2_5)}
         </p>
 
-        <p className="font-weight-bold mb-1">• High default gas price</p>
-        <p>&nbsp;&nbsp;set your gas price manually to 0.06 GWEI</p>
-
-        <p className="font-weight-bold mb-1">
-          • ETH checksum ETH instead of RSK checksume
-        </p>
-        <p>
-          &nbsp;&nbsp;use lower case addresses as receiver for manual
-          transactionsI
-        </p>
-
-        <p className="font-weight-bold mb-1">
-          • Shows price as ETH instead of (r)BTC
-        </p>
-        <p>
-          &nbsp;&nbsp;currently we suggest checking your token balances in the
-          SOVRYN My Wallet section.
-        </p>
+        <StyledList>
+          <li className="mb-3">
+            <div className="font-weight-bold mb-1">
+              {t(
+                translations.notifyDialog.metamaskAlert.knownErrors
+                  .defaultGasPrice.title,
+              )}
+            </div>
+            <div>
+              {t(
+                translations.notifyDialog.metamaskAlert.knownErrors
+                  .defaultGasPrice.description,
+              )}
+            </div>
+          </li>
+          <li className="mb-3">
+            <div className="font-weight-bold mb-1">
+              {t(
+                translations.notifyDialog.metamaskAlert.knownErrors.checksum
+                  .title,
+              )}
+            </div>
+            <div>
+              {t(
+                translations.notifyDialog.metamaskAlert.knownErrors.checksum
+                  .description,
+              )}
+            </div>
+          </li>
+          <li className="mb-3">
+            <div className="font-weight-bold mb-1">
+              {t(
+                translations.notifyDialog.metamaskAlert.knownErrors.price.title,
+              )}
+            </div>
+            <div>
+              {t(
+                translations.notifyDialog.metamaskAlert.knownErrors.price
+                  .description,
+              )}
+            </div>
+          </li>
+        </StyledList>
       </div>
     </>
   );

--- a/src/app/components/NotificationForm/NotificationFormComponent/index.tsx
+++ b/src/app/components/NotificationForm/NotificationFormComponent/index.tsx
@@ -47,9 +47,9 @@ export function NotificationFormComponent(props: Props) {
       {text[props.formType].title}
       <div className="row">
         <FormGroup
-          label="Name / Pseudonym"
+          label={t(s.dialog.form.name.label)}
           labelFor="text-input"
-          labelInfo="(required)"
+          labelInfo={t(s.dialog.form.name.info)}
           className="col-md-6 col-sm-12"
         >
           <InputGroup
@@ -57,13 +57,13 @@ export function NotificationFormComponent(props: Props) {
             name="name"
             value={props.name}
             onChange={props.onChange}
-            placeholder="name / pseudonym"
+            placeholder={t(s.dialog.form.name.placeholder)}
           />
         </FormGroup>
         <FormGroup
-          label="Email Address"
+          label={t(s.dialog.form.email.label)}
           labelFor="email-input"
-          labelInfo="(required)"
+          labelInfo={t(s.dialog.form.email.info)}
           className="col-md-6 col-sm-12"
         >
           <InputGroup
@@ -72,7 +72,7 @@ export function NotificationFormComponent(props: Props) {
             name="email"
             value={props.email}
             onChange={props.onChange}
-            placeholder="email@email.com"
+            placeholder={t(s.dialog.form.email.placeholder)}
           />
         </FormGroup>
       </div>
@@ -106,7 +106,7 @@ export function NotificationFormComponent(props: Props) {
         </div>
         {props.response !== 'success' && props.response && (
           <div className="row p-3">
-            <p className="text-red">There was an error submitting your form</p>
+            <p className="text-red">{t(s.dialog.error)}</p>
           </div>
         )}
       </div>

--- a/src/app/components/NotificationForm/NotificationFormComponent/index.tsx
+++ b/src/app/components/NotificationForm/NotificationFormComponent/index.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 export function NotificationFormComponent(props: Props) {
   const { t } = useTranslation();
-  const s = translations.notificationFromContainer;
+  const s = translations.notificationFormContainer;
   const text = {
     signup: {
       buttonText: 'submit',

--- a/src/app/components/NotificationForm/NotificationFormContainer/index.tsx
+++ b/src/app/components/NotificationForm/NotificationFormContainer/index.tsx
@@ -154,17 +154,17 @@ export function NotificationForm() {
           text={`${
             foundUser
               ? t(
-                  translations.notificationFromContainer
+                  translations.notificationFormContainer
                     .emailSettingsBtn_update,
                 )
-              : t(translations.notificationFromContainer.emailSettingsBtn_get)
+              : t(translations.notificationFormContainer.emailSettingsBtn_get)
           }`}
           onClick={() => setShowForm(true)}
         />
       </div>
       <CustomDialog
         show={showForm}
-        title={t(translations.notificationFromContainer.dialog.title)}
+        title={t(translations.notificationFormContainer.dialog.title)}
         onClose={() => resetForm()}
         content={
           <div>
@@ -185,14 +185,14 @@ export function NotificationForm() {
                 )}
                 {response === 'success' && !foundUser && (
                   <div>
-                    {t(translations.notificationFromContainer.updated_success)}
+                    {t(translations.notificationFormContainer.updated_success)}
                   </div>
                 )}
 
                 {response === 'success' && foundUser && (
                   <div>
                     {t(
-                      translations.notificationFromContainer
+                      translations.notificationFormContainer
                         .updated_success_user,
                     )}
                   </div>

--- a/src/app/components/NotificationForm/NotificationFormContainer/index.tsx
+++ b/src/app/components/NotificationForm/NotificationFormContainer/index.tsx
@@ -6,6 +6,8 @@
 
 import React, { useReducer, useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
+import { useTranslation } from 'react-i18next';
+import { translations } from '../../../../locales/i18n';
 import { useAccount } from '../../../hooks/useAccount';
 import { NotificationFormComponent } from '../NotificationFormComponent';
 import { EmailNotificationButton } from '../EmailNotificationButton';
@@ -14,6 +16,7 @@ import { Sovryn } from '../../../../utils/sovryn';
 import { backendUrl, currentChainId } from '../../../../utils/classifiers';
 
 export function NotificationForm() {
+  const { t } = useTranslation();
   const mailSrv = backendUrl[currentChainId];
 
   const walletAddress = useAccount();
@@ -149,14 +152,19 @@ export function NotificationForm() {
       <div className={`d-none ${!loading && walletAddress && 'd-inline'}`}>
         <EmailNotificationButton
           text={`${
-            foundUser ? 'Update email settings' : 'Get email notifications'
+            foundUser
+              ? t(
+                  translations.notificationFromContainer
+                    .emailSettingsBtn_update,
+                )
+              : t(translations.notificationFromContainer.emailSettingsBtn_get)
           }`}
           onClick={() => setShowForm(true)}
         />
       </div>
       <CustomDialog
         show={showForm}
-        title="Email Notifications"
+        title={t(translations.notificationFromContainer.dialog.title)}
         onClose={() => resetForm()}
         content={
           <div>
@@ -177,13 +185,17 @@ export function NotificationForm() {
                 )}
                 {response === 'success' && !foundUser && (
                   <div>
-                    You will now receive email notifications about margin calls
-                    and liquidated positions.
+                    {t(translations.notificationFromContainer.updated_success)}
                   </div>
                 )}
 
                 {response === 'success' && foundUser && (
-                  <div>Your details have been updated.</div>
+                  <div>
+                    {t(
+                      translations.notificationFromContainer
+                        .updated_success_user,
+                    )}
+                  </div>
                 )}
               </div>
             )}

--- a/src/app/containers/ActiveUserLoans/index.tsx
+++ b/src/app/containers/ActiveUserLoans/index.tsx
@@ -4,6 +4,8 @@
  *
  */
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { translations } from '../../../locales/i18n';
 import { useAccount } from 'app/hooks/useAccount';
 import { useGetActiveLoans } from 'app/hooks/trading/useGetActiveLoans';
 import { ActiveLoanTableContainer } from 'app/components/ActiveUserLoanContainer/components/ActiveLoanTableContainer';
@@ -15,6 +17,7 @@ interface Props {
 }
 
 export function ActiveUserLoans(props: Props) {
+  const { t } = useTranslation();
   const account = useAccount();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { value, loading } = useGetActiveLoans(
@@ -34,21 +37,21 @@ export function ActiveUserLoans(props: Props) {
     return (
       <>
         <div className="container" style={{ padding: '20px' }}>
-          You do not have any active trades.
+          {t(translations.activeUserLoans.text)}
         </div>
         <InfoBox
           icon="info-sign"
           content={
             <>
-              Need help making a transaction? Read our guide on{' '}
+              {t(translations.activeUserLoans.info.line_1)}
               <a
                 href="https://sovryn.app/blog/how-to-earn-and-leverage-bitcoin.html"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                how to trade and lend with Sovryn
+                {t(translations.activeUserLoans.info.line_2)}
               </a>
-              .
+              {t(translations.activeUserLoans.info.line_3)}
             </>
           }
           localStorageRef="txHelpInfoBox"

--- a/src/app/containers/BorrowHistory/index.tsx
+++ b/src/app/containers/BorrowHistory/index.tsx
@@ -31,24 +31,24 @@ export function BorrowHistory(props: Props) {
   const columns = React.useMemo(
     () => [
       {
-        Header: 'Borrowed',
+        Header: t(translations.borrowHistory.table.headers.borrowAmount),
         accessor: 'borrowAmount',
         sortType: 'alphanumeric',
         sortable: true,
       },
       {
-        Header: 'Collateral',
+        Header: t(translations.borrowHistory.table.headers.collateralAmount),
         accessor: 'collateralAmount',
         sortType: 'alphanumeric',
         sortable: true,
       },
       {
-        Header: 'Interest APR',
+        Header: t(translations.borrowHistory.table.headers.interestAPR),
         accessor: 'interestAPR',
         sortable: true,
       },
       {
-        Header: 'Date',
+        Header: t(translations.borrowHistory.table.headers.timestamp),
         accessor: 'timestamp',
         sortable: true,
       },
@@ -57,7 +57,7 @@ export function BorrowHistory(props: Props) {
         accessor: 'actions',
       },
     ],
-    [],
+    [t],
   );
   const data = React.useMemo(() => {
     return events.map(item => {

--- a/src/app/containers/WalletPage/index.tsx
+++ b/src/app/containers/WalletPage/index.tsx
@@ -47,14 +47,14 @@ export function WalletPage() {
         <div className="d-flex flex-row align-items-center justify-content-start">
           <div className="mr-2 ml-2">
             <Tab
-              text="My assets"
+              text={t(translations.walletPage.tabs.userAssets)}
               active={activeAssets}
               onClick={() => setActiveAssets(true)}
             />
           </div>
           <div>
             <Tab
-              text="NFTS"
+              text={t(translations.walletPage.tabs.userNFTS)}
               active={!activeAssets}
               onClick={() => setActiveAssets(false)}
             />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -655,5 +655,43 @@
       "pendingForUserTitle": "Review Transaction",
       "pendingForUserText": "Review and confirm transaction in your wallet"
     }
+  },
+  "notifyDialog": {
+    "heading": "Caution… No Really",
+    "acceptTerms": "I have read and understand that I am responsible for my own Sovrynity",
+    "salesBtn": "I Understand",
+    "generalAlert": {
+      "p1": "SOVRYN is a decentralized bitcoin trading and lending platform, the first of it kind!",
+      "p2": "Only you control and have access to your wealth, any actions you take could cause a potential loss of funds.",
+      "p3": "Make sure to check all transaction fee prices before proceeding as third party wallets may automatically present high fees.",
+      "p4_1": "Please visit our ",
+      "p4_2": "FAQ",
+      "p4_3": " if you have any questions.",
+      "p5_1": "If you’re new to DeFi, here is the ",
+      "p5_2": "tutorial",
+      "p5_3": " on how to use SOVRYN."
+    },
+    "metamaskAlert": {
+      "p1": "We noticed you have MetaMask installed.",
+      "p2_1": "There are known issues when using MetaMask with SOVRYN. We suggest using a browser wallet like ",
+      "p2_2": "Liquality Wallet",
+      "p2_3": " or ",
+      "p2_4": "Nifty Wallet",
+      "p2_5": ". If you wish to continue with MetaMask please be aware of the following known errors:",
+      "knownErrors": {
+        "defaultGasPrice": {
+          "title": "High default gas price",
+          "description": "set your gas price manually to 0.06 GWEI"
+        },
+        "checksum": {
+          "title": "ETH checksum instead of RSK checksum",
+          "description": "use lower case addresses as receiver for manual transactions"
+        },
+        "price": {
+          "title": "Shows price as ETH instead of (r)BTC",
+          "description": "currently we suggest checking your token balances in the SOVRYN My Wallet section."
+        }
+      }
+    }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -238,7 +238,14 @@
   "notificationFromContainer": {
     "want": "Want to receive email notifications about margin calls and liquidated positions?",
     "update": "Update the name or email address associated with this wallet address.",
-    "recieve": "I would like to receive emails about updates and new features from Sovryn"
+    "recieve": "I would like to receive emails about updates and new features from Sovryn",
+    "emailSettingsBtn_update": "Update email settings",
+    "emailSettingsBtn_get": "Get email notifications",
+    "dialog": {
+      "title": "Email Notifications"
+    },
+    "updated_success": "You will now receive email notifications about margin calls and liquidated positions.",
+    "updated_success_user": "Your details have been updated."
   },
   "whiteListedNotification": {
     "text": "Currently Sovryn is available for invited users only and your wallet is not yet whitelisted. All interactions is disabled until you switch to whitelisted wallet or get whitelisted for current one."
@@ -278,6 +285,14 @@
   },
   "activeUserBorrows": {
     "text": "You do not have any active loans."
+  },
+  "activeUserLoans": {
+    "text": "You do not have any active trades.",
+    "info": {
+      "line_1": "Need help making a transaction? Read our guide on ",
+      "line_2": " how to trade and lend with Sovryn",
+      "line_3": "."
+    }
   },
   "topUpTradingPositionHandler": {
     "title": "Top Up position",
@@ -517,6 +532,10 @@
     "meta": {
       "title": "My Wallet",
       "description": "Information about connected wallet"
+    },
+    "tabs": {
+      "userAssets": "My assets",
+      "userNFTS": "NFTS"
     }
   },
   "salesPage": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -235,7 +235,7 @@
     "hintTwo": "Top up your wallet at",
     "hintThree": "and get started!"
   },
-  "notificationFromContainer": {
+  "notificationFormContainer": {
     "want": "Want to receive email notifications about margin calls and liquidated positions?",
     "update": "Update the name or email address associated with this wallet address.",
     "recieve": "I would like to receive emails about updates and new features from Sovryn",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -242,7 +242,20 @@
     "emailSettingsBtn_update": "Update email settings",
     "emailSettingsBtn_get": "Get email notifications",
     "dialog": {
-      "title": "Email Notifications"
+      "title": "Email Notifications",
+      "form": {
+        "name": {
+          "label": "Name / Pseudonym",
+          "info": "(required)",
+          "placeholder": "name / pseudonym"
+        },
+        "email": {
+          "label": "Email Address",
+          "info": "(required)",
+          "placeholder": "email@email.com"
+        }
+      },
+      "error": "There was an error submitting your form"
     },
     "updated_success": "You will now receive email notifications about margin calls and liquidated positions.",
     "updated_success_user": "Your details have been updated."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -306,7 +306,14 @@
     "walletNote": "Connect your wallet first!"
   },
   "borrowHistory": {
-    "table": {},
+    "table": {
+      "headers": {
+        "borrowAmount": "Borrowed",
+        "collateralAmount": "Collateral",
+        "interestAPR": "Interest APR",
+        "timestamp": "Date"
+      }
+    },
     "no_items": "Your borrow history is empty."
   },
   "rskConnectTutorial": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -216,7 +216,20 @@
     "emailSettingsBtn_update": "Update email settings",
     "emailSettingsBtn_get": "Get email notifications",
     "dialog": {
-      "title": "Email Notifications"
+      "title": "Email Notifications",
+      "form": {
+        "name": {
+          "label": "Name / Pseudonym",
+          "info": "(required)",
+          "placeholder": "name / pseudonym"
+        },
+        "email": {
+          "label": "Email Address",
+          "info": "(required)",
+          "placeholder": "email@email.com"
+        }
+      },
+      "error": "There was an error submitting your form"
     },
     "updated_success": "You will now receive email notifications about margin calls and liquidated positions.",
     "updated_success_user": "Your details have been updated."

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -212,7 +212,14 @@
   "notificationFromContainer": {
     "want": "¿Deseas recibir notificaciones por correo sobre alertas de tus posiciones de margen y posiciones liquidadas?",
     "update": "Actualiza el nombre o la dirección de correo asociados con esta dirección de cartera.",
-    "recieve": "Me gustaría recibir correos sobre actualizaciones y nuevas características de Sovryn"
+    "recieve": "Me gustaría recibir correos sobre actualizaciones y nuevas características de Sovryn",
+    "emailSettingsBtn_update": "Update email settings",
+    "emailSettingsBtn_get": "Get email notifications",
+    "dialog": {
+      "title": "Email Notifications"
+    },
+    "updated_success": "You will now receive email notifications about margin calls and liquidated positions.",
+    "updated_success_user": "Your details have been updated."
   },
   "whiteListedNotification": {
     "text": "Actualmente Sovryn esta disponible solo para usuarios invitados y tu cartera no está en la lista de invitados. Todo intercambio estará deshabilitado hasta que conmutes a una cartera invitada o tu cartera actual reciba un token de invitación."
@@ -244,6 +251,14 @@
   },
   "activeUserBorrows": {
     "text": "No posees créditos activos."
+  },
+  "activeUserLoans": {
+    "text": "You do not have any active trades.",
+    "info": {
+      "line_1": "Need help making a transaction? Read our guide on ",
+      "line_2": " how to trade and lend with Sovryn",
+      "line_3": "."
+    }
   },
   "topUpTradingPositionHandler": {
     "title": "Recargar Posición",
@@ -398,6 +413,16 @@
   "topUpBtcDialog": {
     "meta": {
       "title": "Re-Carga"
+    }
+  },
+  "walletPage": {
+    "meta": {
+      "title": "My Wallet",
+      "description": "Information about connected wallet"
+    },
+    "tabs": {
+      "userAssets": "My assets",
+      "userNFTS": "NFTS"
     }
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -424,5 +424,43 @@
       "userAssets": "My assets",
       "userNFTS": "NFTS"
     }
+  },
+  "notifyDialog": {
+    "heading": "Caution… No Really",
+    "acceptTerms": "I have read and understand that I am responsible for my own Sovrynity",
+    "salesBtn": "I Understand",
+    "generalAlert": {
+      "p1": "SOVRYN is a decentralized bitcoin trading and lending platform, the first of it kind!",
+      "p2": "Only you control and have access to your wealth, any actions you take could cause a potential loss of funds.",
+      "p3": "Make sure to check all transaction fee prices before proceeding as third party wallets may automatically present high fees.",
+      "p4_1": "Please visit our ",
+      "p4_2": "FAQ",
+      "p4_3": " if you have any questions.",
+      "p5_1": "If you’re new to DeFi, here is the ",
+      "p5_2": "tutorial",
+      "p5_3": " on how to use SOVRYN."
+    },
+    "metamaskAlert": {
+      "p1": "We noticed you have MetaMask installed.",
+      "p2_1": "There are known issues when using MetaMask with SOVRYN. We suggest using a browser wallet like ",
+      "p2_2": "Liquality Wallet",
+      "p2_3": " or ",
+      "p2_4": "Nifty Wallet",
+      "p2_5": ". If you wish to continue with MetaMask please be aware of the following known errors:",
+      "knownErrors": {
+        "defaultGasPrice": {
+          "title": "High default gas price",
+          "description": "set your gas price manually to 0.06 GWEI"
+        },
+        "checksum": {
+          "title": "ETH checksum instead of RSK checksum",
+          "description": "use lower case addresses as receiver for manual transactions"
+        },
+        "price": {
+          "title": "Shows price as ETH instead of (r)BTC",
+          "description": "currently we suggest checking your token balances in the SOVRYN My Wallet section."
+        }
+      }
+    }
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -272,7 +272,14 @@
     "walletNote": "¡Conecta tu Cartera Primero!"
   },
   "borrowHistory": {
-    "table": {},
+    "table": {
+      "headers": {
+        "borrowAmount": "Borrowed",
+        "collateralAmount": "Collateral",
+        "interestAPR": "Interest APR",
+        "timestamp": "Date"
+      }
+    },
     "no_items": "Tu historial de crédito está vacío."
   },
   "rskConnectTutorial": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -209,7 +209,7 @@
     "hintTwo": "Recarga tu cartera con",
     "hintThree": "¡y empieza!"
   },
-  "notificationFromContainer": {
+  "notificationFormContainer": {
     "want": "¿Deseas recibir notificaciones por correo sobre alertas de tus posiciones de margen y posiciones liquidadas?",
     "update": "Actualiza el nombre o la dirección de correo asociados con esta dirección de cartera.",
     "recieve": "Me gustaría recibir correos sobre actualizaciones y nuevas características de Sovryn",

--- a/src/locales/pt_br/translation.json
+++ b/src/locales/pt_br/translation.json
@@ -238,7 +238,14 @@
   "notificationFromContainer": {
     "want": "Deseja receber notificações por e-mail sobre chamadas de margem e posições liquidadas?",
     "update": "Atualize o nome ou endereço de e-mail associado a este endereço de carteira.",
-    "recieve": "Eu gostaria de receber e-mails sobre atualizações e novos recursos da Sovryn"
+    "recieve": "Eu gostaria de receber e-mails sobre atualizações e novos recursos da Sovryn",
+    "emailSettingsBtn_update": "Update email settings",
+    "emailSettingsBtn_get": "Get email notifications",
+    "dialog": {
+      "title": "Email Notifications"
+    },
+    "updated_success": "You will now receive email notifications about margin calls and liquidated positions.",
+    "updated_success_user": "Your details have been updated."
   },
   "whiteListedNotification": {
     "text": "Atualmente a Sovryn está disponível apenas para usuários convidados e sua carteira ainda não está na lista de permissões. Todas as interações estão desativadas até que o endereço da sua carteira esteja liberado."
@@ -278,6 +285,14 @@
   },
   "activeUserBorrows": {
     "text": "Você não tem nenhum empréstimo ativo."
+  },
+  "activeUserLoans": {
+    "text": "You do not have any active trades.",
+    "info": {
+      "line_1": "Need help making a transaction? Read our guide on ",
+      "line_2": " how to trade and lend with Sovryn",
+      "line_3": "."
+    }
   },
   "topUpTradingPositionHandler": {
     "title": "Aumentar posição",
@@ -517,6 +532,10 @@
     "meta": {
       "title": "Minha carteira",
       "description": "Informações sobre a carteira conectada"
+    },
+    "tabs": {
+      "userAssets": "My assets",
+      "userNFTS": "NFTS"
     }
   },
   "salesPage": {

--- a/src/locales/pt_br/translation.json
+++ b/src/locales/pt_br/translation.json
@@ -654,5 +654,43 @@
       "pendingForUserTitle": "Revisão da transação",
       "pendingForUserText": "Revise e confirme a transação na sua carteira"
     }
+  },
+  "notifyDialog": {
+    "heading": "Caution… No Really",
+    "acceptTerms": "I have read and understand that I am responsible for my own Sovrynity",
+    "salesBtn": "I Understand",
+    "generalAlert": {
+      "p1": "SOVRYN is a decentralized bitcoin trading and lending platform, the first of it kind!",
+      "p2": "Only you control and have access to your wealth, any actions you take could cause a potential loss of funds.",
+      "p3": "Make sure to check all transaction fee prices before proceeding as third party wallets may automatically present high fees.",
+      "p4_1": "Please visit our ",
+      "p4_2": "FAQ",
+      "p4_3": " if you have any questions.",
+      "p5_1": "If you’re new to DeFi, here is the ",
+      "p5_2": "tutorial",
+      "p5_3": " on how to use SOVRYN."
+    },
+    "metamaskAlert": {
+      "p1": "We noticed you have MetaMask installed.",
+      "p2_1": "There are known issues when using MetaMask with SOVRYN. We suggest using a browser wallet like ",
+      "p2_2": "Liquality Wallet",
+      "p2_3": " or ",
+      "p2_4": "Nifty Wallet",
+      "p2_5": ". If you wish to continue with MetaMask please be aware of the following known errors:",
+      "knownErrors": {
+        "defaultGasPrice": {
+          "title": "High default gas price",
+          "description": "set your gas price manually to 0.06 GWEI"
+        },
+        "checksum": {
+          "title": "ETH checksum instead of RSK checksum",
+          "description": "use lower case addresses as receiver for manual transactions"
+        },
+        "price": {
+          "title": "Shows price as ETH instead of (r)BTC",
+          "description": "currently we suggest checking your token balances in the SOVRYN My Wallet section."
+        }
+      }
+    }
   }
 }

--- a/src/locales/pt_br/translation.json
+++ b/src/locales/pt_br/translation.json
@@ -306,7 +306,14 @@
     "walletNote": "Primeiro conecte sua carteira!"
   },
   "borrowHistory": {
-    "table": {},
+    "table": {
+      "headers": {
+        "borrowAmount": "Borrowed",
+        "collateralAmount": "Collateral",
+        "interestAPR": "Interest APR",
+        "timestamp": "Date"
+      }
+    },
     "no_items": "Seu histórico de empréstimos está vazio."
   },
   "rskConnectTutorial": {

--- a/src/locales/pt_br/translation.json
+++ b/src/locales/pt_br/translation.json
@@ -242,7 +242,20 @@
     "emailSettingsBtn_update": "Update email settings",
     "emailSettingsBtn_get": "Get email notifications",
     "dialog": {
-      "title": "Email Notifications"
+      "title": "Email Notifications",
+      "form": {
+        "name": {
+          "label": "Name / Pseudonym",
+          "info": "(required)",
+          "placeholder": "name / pseudonym"
+        },
+        "email": {
+          "label": "Email Address",
+          "info": "(required)",
+          "placeholder": "email@email.com"
+        }
+      },
+      "error": "There was an error submitting your form"
     },
     "updated_success": "You will now receive email notifications about margin calls and liquidated positions.",
     "updated_success_user": "Your details have been updated."

--- a/src/locales/pt_br/translation.json
+++ b/src/locales/pt_br/translation.json
@@ -235,7 +235,7 @@
     "hintTwo": "Carregue sua carteira na",
     "hintThree": "e comece a usar!"
   },
-  "notificationFromContainer": {
+  "notificationFormContainer": {
     "want": "Deseja receber notificações por e-mail sobre chamadas de margem e posições liquidadas?",
     "update": "Atualize o nome ou endereço de e-mail associado a este endereço de carteira.",
     "recieve": "Eu gostaria de receber e-mails sobre atualizações e novos recursos da Sovryn",


### PR DESCRIPTION
Added strings for all text that is referenced in #143, with the exception of this one (as I believe this is just a temporary warning):
https://github.com/DistributedCollective/Sovryn-frontend/issues/143#issuecomment-766356682

All of these will need appropriate translations, I have just copied over the english text.

There is one string that I spotted in NotificationFormContainer::86 that looks like it needs translation, but I'm not sure how you would like to handle this one as there are some newline characters and piping that probably shouldn't go into the translation json:
 `${timestamp} \n \n Please confirm that the details associated with this account will now be: \n \n Username: ${name} \n Email: ${email}`

I also reviewed the rest of the Components/Containers in the app and have found a number of other locations where translations should be applied - let me know if you'd like a list of those submitted as separate ticket/pull request.