### PR TITLE
Update asset value tooltip precision for #344

### DIFF
--- a/src/app/components/ActiveUserLoanContainer/components/ActiveLoanTableDesktop/index.tsx
+++ b/src/app/components/ActiveUserLoanContainer/components/ActiveLoanTableDesktop/index.tsx
@@ -11,6 +11,7 @@ import {
   faLongArrowAltUp,
   faLongArrowAltDown,
 } from '@fortawesome/free-solid-svg-icons';
+import { weiTo18 } from '../../../../../utils/blockchain/math-helpers';
 import { useTranslation } from 'react-i18next';
 import { translations } from '../../../../../locales/i18n';
 import { LoadableValue } from '../../../LoadableValue';
@@ -146,7 +147,7 @@ export function ActiveLoanTableDesktop(props: Props) {
                           {item.currency}
                         </>
                       }
-                      tooltip={item.positionSize}
+                      tooltip={weiTo18(item.positionSize)}
                     />
                   </td>
                   <td>

--- a/src/app/components/AssetWalletBalance/index.tsx
+++ b/src/app/components/AssetWalletBalance/index.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Asset } from 'types/asset';
-import { weiToFixed } from 'utils/blockchain/math-helpers';
+import { weiTo18, weiToFixed } from 'utils/blockchain/math-helpers';
 import { useAssetBalanceOf } from 'app/hooks/useAssetBalanceOf';
 import { useIsConnected } from 'app/hooks/useAccount';
 import { translations } from 'locales/i18n';
@@ -41,7 +41,7 @@ export function AssetWalletBalance(props: Props) {
             <LoadableValue
               value={weiToFixed(value, 4)}
               loading={loading}
-              tooltip={<>{value}</>}
+              tooltip={<>{weiTo18(value)}</>}
             />
           </span>
         </div>

--- a/src/app/containers/LiquidityAddContainer/ExpectedPoolTokens.tsx
+++ b/src/app/containers/LiquidityAddContainer/ExpectedPoolTokens.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Text } from '@blueprintjs/core';
 import { LoadableValue } from '../../components/LoadableValue';
-import { weiTo4 } from '../../../utils/blockchain/math-helpers';
+import { weiTo4, weiTo18 } from '../../../utils/blockchain/math-helpers';
 import { translations } from '../../../locales/i18n';
 import { useExpectedPoolTokens } from '../../hooks/amm/useExpectedPoolTokens';
 import { Asset } from '../../../types/asset';
@@ -28,7 +28,7 @@ export function ExpectedPoolTokens({ pool, asset, amount }: Props) {
                   {weiTo4(expectedPoolTokens.value)}
                 </Text>
               }
-              tooltip={expectedPoolTokens.value}
+              tooltip={weiTo18(expectedPoolTokens.value)}
             />
           </div>
           <div className="small">{t(translations.liquidity.token)}</div>

--- a/src/app/containers/LiquidityRemoveContainer/index.tsx
+++ b/src/app/containers/LiquidityRemoveContainer/index.tsx
@@ -137,7 +137,7 @@ export function LiquidityRemoveContainer(props: Props) {
                     {weiTo4(targetValue[0])} {sourceToken}
                   </Text>
                 }
-                tooltip={targetValue[0]}
+                tooltip={weiTo18(targetValue[0])}
               />
             </div>
             <div className="small">
@@ -153,7 +153,7 @@ export function LiquidityRemoveContainer(props: Props) {
                     {weiTo4(targetValue[1])} {sourceToken}
                   </Text>
                 }
-                tooltip={targetValue[1]}
+                tooltip={weiTo18(targetValue[1])}
               />
             </div>
             <div className="small">{t(translations.liquidity.fee)}</div>

--- a/src/app/containers/RepayPositionHandler/RepayPositionForm.tsx
+++ b/src/app/containers/RepayPositionHandler/RepayPositionForm.tsx
@@ -17,11 +17,7 @@ import { TradeButton } from '../../components/TradeButton';
 import { AssetWalletBalance } from '../../components/AssetWalletBalance';
 import { AssetsDictionary } from '../../../utils/dictionaries/assets-dictionary';
 import { useAssetBalanceOf } from '../../hooks/useAssetBalanceOf';
-import {
-  normalizeWei,
-  weiTo18,
-  weiTo4,
-} from '../../../utils/blockchain/math-helpers';
+import { weiTo4, weiTo18 } from '../../../utils/blockchain/math-helpers';
 import { DummyField } from '../../components/DummyField';
 import { useApproveAndCloseWithDeposit } from '../../hooks/trading/useApproveAndCloseWithDeposit';
 import { LoadableValue } from '../../components/LoadableValue';
@@ -111,7 +107,7 @@ export function RepayPositionForm({ loan }: Props) {
           <LoadableValue
             loading={false}
             value={weiTo4(receiveAmount)}
-            tooltip={<>{normalizeWei(receiveAmount)}</>}
+            tooltip={<>{weiTo18(receiveAmount)}</>}
           />{' '}
           {collateralAsset}
         </small>


### PR DESCRIPTION
I've updated these to consistently use `weiTo18()` formatting instead of wei's