### PR TITLE
Add testnet settings to EngageWalletDialog setup tutorial

### DIFF
--- a/src/app/containers/EngageWalletDialog/component/screen2/index.tsx
+++ b/src/app/containers/EngageWalletDialog/component/screen2/index.tsx
@@ -15,6 +15,12 @@ import crater from 'assets/images/tutorial/crater.svg';
 import { Icon } from '@blueprintjs/core';
 import { useContent } from '../../../../hooks/tutorial/useContent';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import {
+  blockExplorers,
+  currentChainId,
+  networkNames,
+  rpcWalletURLs,
+} from '../../../../../utils/classifiers';
 
 interface Props {
   onNetwork: boolean;
@@ -102,16 +108,16 @@ export function Screen2(props: Props) {
               <div className="col-5">
                 {t(translations.rskConnectTutorial.input_settings.network)}
               </div>
-              <div className="col-7">RSK Mainnet</div>
+              <div className="col-7">{networkNames[currentChainId]}</div>
             </div>
             <div className="row">
               <div className="col-5">
                 {t(translations.rskConnectTutorial.input_settings.new_RPC)}
               </div>
               <div className="col-7">
-                <CopyToClipboard text="https://public-node.rsk.co">
+                <CopyToClipboard text={rpcWalletURLs[currentChainId]}>
                   <span className="cursor-pointer">
-                    https://public-node.rsk.co <Icon icon="duplicate" />
+                    {rpcWalletURLs[currentChainId]} <Icon icon="duplicate" />
                   </span>
                 </CopyToClipboard>
               </div>
@@ -120,7 +126,7 @@ export function Screen2(props: Props) {
               <div className="col-5">
                 {t(translations.rskConnectTutorial.input_settings.chain_Id)}
               </div>
-              <div className="col-7">30</div>
+              <div className="col-7">{currentChainId}</div>
             </div>
             <div className="row">
               <div className="col-5">
@@ -133,9 +139,9 @@ export function Screen2(props: Props) {
                 {t(translations.rskConnectTutorial.input_settings.explorer_url)}
               </div>
               <div className="col-7">
-                <CopyToClipboard text="https://explorer.rsk.co">
+                <CopyToClipboard text={blockExplorers[currentChainId]}>
                   <span className="cursor-pointer">
-                    https://explorer.rsk.co <Icon icon="duplicate" />
+                    {blockExplorers[currentChainId]} <Icon icon="duplicate" />
                   </span>
                 </CopyToClipboard>
               </div>

--- a/src/app/containers/EngageWalletDialog/component/screen4/index.tsx
+++ b/src/app/containers/EngageWalletDialog/component/screen4/index.tsx
@@ -15,6 +15,12 @@ import scanQR from 'assets/images/tutorial/scanQr.svg';
 import { Icon } from '@blueprintjs/core';
 import { useContent } from '../../../../hooks/tutorial/useContent';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import {
+  blockExplorers,
+  currentChainId,
+  networkNames,
+  rpcWalletURLs,
+} from '../../../../../utils/classifiers';
 
 export function Screen4(props) {
   const { t } = useTranslation();
@@ -69,7 +75,7 @@ export function Screen4(props) {
               <div className="col-5">
                 {t(translations.rskConnectTutorial.input_settings.network)}
               </div>
-              <div className="col-7">RSK Mainnet</div>
+              <div className="col-7">{networkNames[currentChainId]}</div>
             </div>
             <div className="row">
               <div className="col-5">
@@ -77,11 +83,11 @@ export function Screen4(props) {
               </div>
               <div className="col-7">
                 <CopyToClipboard
-                  text="https://public-node.rsk.co"
+                  text={rpcWalletURLs[currentChainId]}
                   onCopy={() => alert('Copied!')}
                 >
                   <span className="cursor-pointer">
-                    https://public-node.rsk.co <Icon icon="duplicate" />
+                    {rpcWalletURLs[currentChainId]} <Icon icon="duplicate" />
                   </span>
                 </CopyToClipboard>
               </div>
@@ -90,7 +96,7 @@ export function Screen4(props) {
               <div className="col-5">
                 {t(translations.rskConnectTutorial.input_settings.chain_Id)}
               </div>
-              <div className="col-7">30</div>
+              <div className="col-7">{currentChainId}</div>
             </div>
             <div className="row">
               <div className="col-5">
@@ -108,7 +114,7 @@ export function Screen4(props) {
                   onCopy={() => alert('Copied!')}
                 >
                   <span className="cursor-pointer">
-                    https://explorer.rsk.co <Icon icon="duplicate" />
+                    {blockExplorers[currentChainId]} <Icon icon="duplicate" />
                   </span>
                 </CopyToClipboard>
               </div>

--- a/src/utils/classifiers.ts
+++ b/src/utils/classifiers.ts
@@ -36,6 +36,11 @@ export const rpcNodes = {
   31: 'https://testnet2.sovryn.app/rpc',
 };
 
+export const rpcWalletURLs = {
+  30: 'https://public-node.rsk.co',
+  31: 'https://public-node.testnet.rsk.co',
+};
+
 export const readNodes = {
   30: 'wss://mainnet2.sovryn.app/ws',
   31: 'wss://testnet2.sovryn.app/ws',


### PR DESCRIPTION
The engage wallet tutorial shows Mainnet settings, even when on Testnet - I've updated this so it pulls through the relevant values depending on which network is currently in use