### PR TITLE
Update rpcNode urls (and removed duplicate node defs)

### DIFF
--- a/src/app/containers/EngageWalletDialog/component/screen2/index.tsx
+++ b/src/app/containers/EngageWalletDialog/component/screen2/index.tsx
@@ -19,7 +19,7 @@ import {
   blockExplorers,
   currentChainId,
   networkNames,
-  rpcWalletURLs,
+  rpcNodes,
 } from '../../../../../utils/classifiers';
 
 interface Props {
@@ -115,9 +115,9 @@ export function Screen2(props: Props) {
                 {t(translations.rskConnectTutorial.input_settings.new_RPC)}
               </div>
               <div className="col-7">
-                <CopyToClipboard text={rpcWalletURLs[currentChainId]}>
+                <CopyToClipboard text={rpcNodes[currentChainId]}>
                   <span className="cursor-pointer">
-                    {rpcWalletURLs[currentChainId]} <Icon icon="duplicate" />
+                    {rpcNodes[currentChainId]} <Icon icon="duplicate" />
                   </span>
                 </CopyToClipboard>
               </div>

--- a/src/app/containers/EngageWalletDialog/component/screen4/index.tsx
+++ b/src/app/containers/EngageWalletDialog/component/screen4/index.tsx
@@ -19,7 +19,7 @@ import {
   blockExplorers,
   currentChainId,
   networkNames,
-  rpcWalletURLs,
+  rpcNodes,
 } from '../../../../../utils/classifiers';
 
 export function Screen4(props) {
@@ -83,11 +83,11 @@ export function Screen4(props) {
               </div>
               <div className="col-7">
                 <CopyToClipboard
-                  text={rpcWalletURLs[currentChainId]}
+                  text={rpcNodes[currentChainId]}
                   onCopy={() => alert('Copied!')}
                 >
                   <span className="cursor-pointer">
-                    {rpcWalletURLs[currentChainId]} <Icon icon="duplicate" />
+                    {rpcNodes[currentChainId]} <Icon icon="duplicate" />
                   </span>
                 </CopyToClipboard>
               </div>

--- a/src/utils/classifiers.ts
+++ b/src/utils/classifiers.ts
@@ -32,13 +32,8 @@ export const networkNames = {
 };
 
 export const rpcNodes = {
-  30: 'https://mainnet2.sovryn.app/rpc',
-  31: 'https://testnet2.sovryn.app/rpc',
-};
-
-export const rpcWalletURLs = {
-  30: 'https://public-node.rsk.co',
-  31: 'https://public-node.testnet.rsk.co',
+  30: 'https://mainnet.sovryn.app/rpc',
+  31: 'https://testnet.sovryn.app/rpc',
 };
 
 export const readNodes = {


### PR DESCRIPTION
The team mentioned in Discord that the RPC node URLs on the Gitbook docs aren't up to date, so I've modified my recent change from 99c0d30 to use the correct URLs (and removed the duplicate node definitions I mistakenly added last time)