### PR TITLE
Changed stats page to include tvl and trading volume

### DIFF
--- a/src/app/containers/StatsPage/components/TVL.tsx
+++ b/src/app/containers/StatsPage/components/TVL.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { backendUrl, currentChainId } from '../../../../utils/classifiers';
+import { SkeletonRow } from '../../../components/Skeleton/SkeletonRow';
+import { TvlData } from '../types';
+
+export function TVL() {
+  const url = backendUrl[currentChainId];
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<TvlData>();
+
+  useEffect(() => {
+    axios
+      .get(url + '/tvl')
+      .then(res => {
+        setData(res.data);
+        setLoading(false);
+      })
+      .catch(e => console.error(e));
+  }, [url]);
+
+  const rowData = [
+    {
+      contract: 'Protocol Contract',
+      btcValue:
+        data &&
+        data?.tvlProtocol.btc_total +
+          data?.tvlProtocol.usd_total * (1 / data?.btc_doc_rate) +
+          data?.tvlProtocol.bpro_total * data?.bpro_btc_rate,
+      usdValue:
+        data &&
+        data?.tvlProtocol.usd_total +
+          data?.tvlProtocol.btc_total * data?.btc_doc_rate +
+          data?.tvlProtocol.bpro_total * data?.bpro_doc_rate,
+    },
+    {
+      contract: 'Lending Contracts',
+      btcValue:
+        data &&
+        data?.tvlLending.btc_total +
+          data?.tvlLending.usd_total * (1 / data?.btc_doc_rate) +
+          data?.tvlLending.bpro_total * data?.bpro_btc_rate,
+      usdValue:
+        data &&
+        data?.tvlLending.usd_total +
+          data?.tvlLending.btc_total * data?.btc_doc_rate +
+          data?.tvlLending.bpro_total * data?.bpro_doc_rate,
+    },
+    {
+      contract: 'Amm Contracts',
+      btcValue:
+        data &&
+        data?.tvlAmm.btc_total +
+          data?.tvlAmm.usd_total * (1 / data?.btc_doc_rate) +
+          data?.tvlAmm.bpro_total * data?.bpro_btc_rate,
+      usdValue:
+        data &&
+        data?.tvlAmm.usd_total +
+          data?.tvlAmm.btc_total * data?.btc_doc_rate +
+          data?.tvlAmm.bpro_total * data?.bpro_doc_rate,
+    },
+    {
+      contract: 'Total',
+      btcValue: data?.total_btc,
+      usdValue: data?.total_usd,
+    },
+  ];
+
+  const rows = rowData.map((row, key) => (
+    <>
+      {loading ? (
+        <SkeletonRow key={key} />
+      ) : (
+        <tr
+          key={key}
+          className={`${
+            row.contract === 'Total' ? 'font-weight-bold border-top' : ''
+          }`}
+        >
+          <td>{row.contract}</td>
+          <td>
+            {row.btcValue?.toLocaleString('en', {
+              maximumFractionDigits: 4,
+              minimumFractionDigits: 4,
+            })}
+          </td>
+          <td>
+            {row.usdValue?.toLocaleString('en', {
+              maximumFractionDigits: 2,
+              minimumFractionDigits: 2,
+            })}
+          </td>
+        </tr>
+      )}
+    </>
+  ));
+
+  return (
+    <div>
+      <table className="w-100">
+        <thead>
+          <tr>
+            <th className="">Contract Type</th>
+            <th className="">Value (BTC)</th>
+            <th className="">Value (USD)</th>
+          </tr>
+        </thead>
+        <tbody className="mt-5">{rows}</tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/containers/StatsPage/components/TradingVolume.tsx
+++ b/src/app/containers/StatsPage/components/TradingVolume.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { backendUrl, currentChainId } from '../../../../utils/classifiers';
+import { SkeletonRow } from '../../../components/Skeleton/SkeletonRow';
+import { TradingVolumeData } from '../types';
+
+export function TradingVolume() {
+  const url = backendUrl[currentChainId];
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<TradingVolumeData>();
+
+  useEffect(() => {
+    axios
+      .get(url + '/trading-volume')
+      .then(res => {
+        setData(res.data);
+        setLoading(false);
+      })
+      .catch(e => console.error(e));
+  }, [url]);
+
+  const rowData = [
+    {
+      title: '24 Hour Volume',
+      col1: `${data && data.total.btc.twentyFourHours.toFixed(4)} BTC`,
+      col2: `${
+        data &&
+        data.total.usd.twentyFourHours.toLocaleString('en', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })
+      } USD`,
+    },
+    {
+      title: 'All Time Volume',
+      col1: `${data && data.total.btc.allTime.toFixed(4)} BTC`,
+      col2: `${
+        data &&
+        data.total.usd.allTime.toLocaleString('en', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })
+      } USD`,
+    },
+  ];
+
+  const rows = rowData.map((row, key) => (
+    <div key={key} className="row sovryn-border mb-3">
+      <div className="col-4">
+        <div className="text-center p-3">
+          <h3>
+            <div className="p-3 text-center w-100">{row.title}</div>
+          </h3>
+        </div>
+      </div>
+      <div className="col-4 bg-secondary border border-black">
+        <div className="text-center p-3">
+          <h3>
+            {loading ? (
+              <SkeletonRow />
+            ) : (
+              <div className="p-3 text-center w-100">{row.col1}</div>
+            )}
+          </h3>
+        </div>
+      </div>
+      <div className="col-4 bg-secondary ">
+        <div className="text-center p-3">
+          <h3>
+            {loading ? (
+              <SkeletonRow />
+            ) : (
+              <div className="p-3 text-center w-100">{row.col2}</div>
+            )}
+          </h3>
+        </div>
+      </div>
+    </div>
+  ));
+
+  return <div>{rows}</div>;
+}

--- a/src/app/containers/StatsPage/index.tsx
+++ b/src/app/containers/StatsPage/index.tsx
@@ -12,6 +12,8 @@ import { translations } from 'locales/i18n';
 import { Header } from '../../components/Header';
 import { Footer } from '../../components/Footer';
 import { StatsRow } from '../../components/StatsRow';
+import { TradingVolume } from './components/TradingVolume';
+import { TVL } from './components/TVL';
 
 export function StatsPage() {
   const { t } = useTranslation();
@@ -21,6 +23,15 @@ export function StatsPage() {
       <Header />
       <main>
         <div className="container mt-5">
+          <h1 className="text-center w-100">Trading Volume</h1>
+          <div className="my-5 mx-3">
+            <TradingVolume />
+          </div>
+          <h1 className="text-center w-100">Total Value Locked</h1>
+          <div className="sovryn-border sovryn-table p-3 mt-5 mb-5">
+            <TVL />
+          </div>
+          <h1 className="text-center w-100">Lending Stats</h1>
           <div className="sovryn-border sovryn-table p-3 mt-5 mb-5">
             <table className="w-100">
               <thead>

--- a/src/app/containers/StatsPage/types.ts
+++ b/src/app/containers/StatsPage/types.ts
@@ -1,0 +1,35 @@
+export type TradingVolumeData = {
+  total: {
+    btc: {
+      allTime: number;
+      twentyFourHours: number;
+    };
+    usd: {
+      allTime: number;
+      twentyFourHours: number;
+    };
+  };
+};
+
+export type TvlData = {
+  tvlLending: {
+    btc_total: number;
+    usd_total: number;
+    bpro_total: number;
+  };
+  tvlAmm: {
+    btc_total: number;
+    usd_total: number;
+    bpro_total: number;
+  };
+  tvlProtocol: {
+    btc_total: number;
+    usd_total: number;
+    bpro_total: number;
+  };
+  btc_doc_rate: number;
+  bpro_doc_rate: number;
+  bpro_btc_rate: number;
+  total_btc: number;
+  total_usd: number;
+};


### PR DESCRIPTION
This is two new components for the "Stats" page of the dapp, showing Trading Volume and TVL,. It looks like this: 
![image](https://user-images.githubusercontent.com/69518422/112858134-7fa00b80-90a9-11eb-967b-85989acc020a.png)
