### PR TITLE
adds a 'Copy Address' MenuItem to WalletConnector

### DIFF
--- a/src/app/containers/WalletConnector/index.tsx
+++ b/src/app/containers/WalletConnector/index.tsx
@@ -11,6 +11,8 @@ import blockies from 'ethereum-blockies';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { toastSuccess } from 'utils/toaster';
 import styled from 'styled-components/macro';
 
 import { translations } from 'locales/i18n';
@@ -70,6 +72,17 @@ const WalletConnectorContainer: React.FC<Props> = props => {
           <Popover
             content={
               <Menu>
+                <CopyToClipboard
+                  text={address}
+                  onCopy={() =>
+                    toastSuccess(<>{t(translations.onCopy.address)}</>, 'copy')
+                  }
+                >
+                  <MenuItem
+                    icon="duplicate"
+                    text={t(translations.wallet.copy_address)}
+                  />
+                </CopyToClipboard>
                 <MenuItem
                   icon="briefcase"
                   text={t(translations.wallet.my_wallet)}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -186,6 +186,7 @@
     "connect_btn": "Engage wallet",
     "disconnect": "Disconnect",
     "my_wallet": "My Wallet",
+    "copy_address": "Copy Address",
     "referrals": "Refer a friend",
     "changeWallet": "Change Wallet"
   },


### PR DESCRIPTION
For hardware wallets there is currently no way to view the wallet's address. This commit adds a 'Copy Address' MenuItem to the WalletConnector drop-down that copies the wallet address into the clipboard.