### PR TITLE
[Liquidity-Mining] Revert incorrect Asset label

### DIFF
--- a/src/app/pages/LiquidityMining/components/AddLiquidityDialog/index.tsx
+++ b/src/app/pages/LiquidityMining/components/AddLiquidityDialog/index.tsx
@@ -83,6 +83,7 @@ export function AddLiquidityDialog({ pool, ...props }: Props) {
             value={asset}
             onChange={value => setAsset(value)}
             options={assets}
+            label={t(translations.liquidityMining.modals.deposit.asset)}
           />
 
           <FormGroup

--- a/src/app/pages/LiquidityMining/components/RemoveLiquidityDialog/index.tsx
+++ b/src/app/pages/LiquidityMining/components/RemoveLiquidityDialog/index.tsx
@@ -123,6 +123,7 @@ export function RemoveLiquidityDialog({ pool, ...props }: Props) {
             value={asset}
             onChange={value => setAsset(value)}
             options={assets}
+            label={t(translations.liquidityMining.modals.withdraw.asset)}
           />
           <FormGroup
             label={t(translations.liquidityMining.modals.withdraw.amount)}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1072,12 +1072,14 @@
       "deposit": {
         "title": "Deposit Liquidity",
         "cta": "Deposit",
+        "asset": "Asset:",
         "amount": "Amount:"
       },
       "withdraw": {
         "title": "Withdraw Liquidity",
         "cta": "Withdraw",
         "amount": "Amount:",
+        "asset": "Asset:",
         "reward": "Reward:"
       }
     },


### PR DESCRIPTION
Reverts incorrectly applied label update for asset selector in pool dialogs (v2 pools), on Liquidity Mining page