### PR TITLE
Remove SOV from the 'asset to collateralize' dropdown in Lend -> Borrow

### DIFF
--- a/src/utils/dictionaries/lending-pool-dictionary.ts
+++ b/src/utils/dictionaries/lending-pool-dictionary.ts
@@ -6,7 +6,6 @@ export class LendingPoolDictionary {
     [
       Asset.RBTC,
       new LendingPool('RBTC', Asset.RBTC, [
-        Asset.SOV,
         Asset.DOC,
         Asset.USDT,
         Asset.BPRO,


### PR DESCRIPTION
Before this patch:
<img width="339" alt="before" src="https://user-images.githubusercontent.com/83920716/122568344-a706d480-d017-11eb-8e0e-ca5af8e20c69.png">
After this patch:
<img width="340" alt="after" src="https://user-images.githubusercontent.com/83920716/122568356-a9692e80-d017-11eb-9390-3e30a8e9b4f1.png">
