### PR TITLE
[Trading Chart] Store user drawings/indicators

### DIFF
--- a/src/app/components/TradingChart/index.tsx
+++ b/src/app/components/TradingChart/index.tsx
@@ -2,7 +2,7 @@
  *
  * TradingChart
  *
- * Implementation of TradingView Charting Library. Please check the following link
+ * Implementation of TradingView Charting Library (v18.043). Please check the following link
  * and make any relevant changes before updating the library version:
  * https://github.com/tradingview/charting_library/wiki/Breaking-Changes
  */
@@ -15,6 +15,7 @@ import {
 
 import { Skeleton } from '../PageSkeleton';
 import Datafeed from './datafeed';
+import Storage from './storage';
 
 export enum Theme {
   LIGHT = 'Light',
@@ -32,20 +33,26 @@ export function TradingChart(props: ChartContainerProps) {
 
   useEffect(() => {
     try {
-      // full list of widget config options here: https://github.com/tradingview/charting_library/wiki/Widget-Constructor
+      // full list of widget config options here: https://github.com/tradingview/charting_library/wiki/Widget-Constructor/cf26598509d8bba6dc95c5fe8208caa5e8474827
       const widgetOptions: any = {
         debug: false,
         symbol: props.symbol,
         datafeed: Datafeed,
+        save_load_adapter: Storage,
+        study_count_limit: 2,
         interval: '30', //default time interval
         timeframe: '3D', //default range
         container_id: 'tv_chart_container', //id of DOM container
         library_path: '/charting_library/', //relative path of library in /public folder
         locale: 'en',
-        enabled_features: [], //full list of features here: https://github.com/tradingview/charting_library/wiki/Featuresets
+        load_last_chart: true, //last chart layout (if present)
+        enabled_features: [
+          'study_templates', //remove to disable storing of indicators
+          'side_toolbar_in_fullscreen_mode',
+        ], //full list of features here: https://github.com/tradingview/charting_library/wiki/Featuresets/c2ec34605fa84781048d32b87a2b08ef1466639a
         disabled_features: [
           'header_symbol_search',
-          'header_saveload',
+          //'header_saveload', //uncomment to disable storing of drawings
           'header_compare',
         ],
         autosize: true,

--- a/src/app/components/TradingChart/storage.ts
+++ b/src/app/components/TradingChart/storage.ts
@@ -1,0 +1,103 @@
+/**
+ * Implementation of TradingView Charting Library api (v18.043)
+ * for saving/loading of Chart Layouts (drawings) and Study Templates (indicators)
+ * using localStorage as lightweight storage solution.
+ *
+ * More information on this and other solutions can be found here:
+ * https://github.com/tradingview/charting_library/wiki/Saving-and-Loading-Charts/0918ee9f5215ebd5a06d0ec9ee2bdffbd5822342
+ */
+import { v4 as uuid } from 'uuid';
+import { local } from 'utils/storage';
+import { chartStorageKey } from 'utils/classifiers';
+
+type StoredCharts = {
+  [id: string]: ChartData;
+};
+
+type ChartData = {
+  id: string;
+  name: string;
+  symbol: string;
+  resolution: string;
+  content: string;
+  timestamp: number;
+};
+
+type StoredTemplates = {
+  [id: string]: TemplateData;
+};
+
+type TemplateData = {
+  name: string;
+  content: string;
+};
+
+/** Local storage keys */
+const LAYOUT_KEY = `${chartStorageKey}.layouts`;
+const TEMPLATE_KEY = `${chartStorageKey}.templates`;
+
+const getJSON = (key: string) => JSON.parse(local.getItem(key) || '{}');
+const setJSON = (key: string, obj: any) =>
+  local.setItem(key, JSON.stringify(obj));
+
+// Details on implemented methods can be found here:
+// https://github.com/tradingview/charting_library/wiki/Saving-and-Loading-Charts/0918ee9f5215ebd5a06d0ec9ee2bdffbd5822342#api-handlers
+export default {
+  /** Chart Layout (drawing) methods **/
+  getAllCharts: () => Promise.resolve(Object.values(getJSON(LAYOUT_KEY)) || []),
+
+  removeChart: (chartID: string) => {
+    const storedCharts: StoredCharts = getJSON(LAYOUT_KEY);
+    if (!storedCharts) return Promise.reject();
+    if (storedCharts[chartID]) delete storedCharts[chartID];
+    setJSON(LAYOUT_KEY, storedCharts);
+    return Promise.resolve();
+  },
+
+  saveChart: (chartData: ChartData) => {
+    let updatedCharts: StoredCharts = getJSON(LAYOUT_KEY);
+    let chartID = chartData.id;
+    if (!updatedCharts[chartID]) chartID = uuid();
+    updatedCharts[chartID] = {
+      ...chartData,
+      id: chartID,
+      timestamp: Date.now() / 1e3,
+    };
+    setJSON(LAYOUT_KEY, updatedCharts);
+    return Promise.resolve(chartID);
+  },
+
+  getChartContent: (chartID: string) => {
+    const storedCharts = getJSON(LAYOUT_KEY);
+    return storedCharts[chartID]
+      ? Promise.resolve(storedCharts[chartID].content)
+      : Promise.reject();
+  },
+
+  /** Chart Study Template (indicator) methods **/
+  getAllStudyTemplates: () =>
+    Promise.resolve(Object.values(getJSON(TEMPLATE_KEY)) || []),
+
+  removeStudyTemplate: (studyTemplateData: TemplateData) => {
+    let storedTemplates: StoredTemplates = getJSON(TEMPLATE_KEY);
+    if (!storedTemplates) return Promise.reject();
+    if (storedTemplates[studyTemplateData.name])
+      delete storedTemplates[studyTemplateData.name];
+    setJSON(TEMPLATE_KEY, storedTemplates);
+    return Promise.resolve();
+  },
+
+  saveStudyTemplate: (studyTemplateData: TemplateData) => {
+    let updatedTemplates: StoredTemplates = getJSON(TEMPLATE_KEY);
+    updatedTemplates[studyTemplateData.name] = studyTemplateData;
+    setJSON(TEMPLATE_KEY, updatedTemplates);
+    return Promise.resolve();
+  },
+
+  getStudyTemplateContent: (studyTemplateData: TemplateData) => {
+    const storedTemplates: StoredTemplates = getJSON(TEMPLATE_KEY);
+    return storedTemplates[studyTemplateData.name]
+      ? Promise.resolve(storedTemplates[studyTemplateData.name].content)
+      : Promise.reject();
+  },
+};

--- a/src/app/components/TradingChart/streaming.ts
+++ b/src/app/components/TradingChart/streaming.ts
@@ -1,8 +1,8 @@
 /**
  * TradingChart "realtime" data stream.
  *
- * Implementation of TradingView Charting Library subscribeBars() and unsubscribeBars():
- * https://github.com/tradingview/charting_library/wiki/JS-Api#subscribebarssymbolinfo-resolution-onrealtimecallback-subscriberuid-onresetcacheneededcallback
+ * Implementation of TradingView Charting Library (v18.043) subscribeBars() and unsubscribeBars():
+ * https://github.com/tradingview/charting_library/wiki/JS-Api/f62fddae9ad1923b9f4c97dbbde1e62ff437b924#subscribebarssymbolinfo-resolution-onrealtimecallback-subscriberuid-onresetcacheneededcallback
  *
  * If the version of the library is updated, then modifications may
  * be necessary to this file and the datafeed.ts file in

--- a/src/utils/classifiers.ts
+++ b/src/utils/classifiers.ts
@@ -41,6 +41,8 @@ export const ethGenesisAddress = '0x0000000000000000000000000000000000000000';
 
 export const sovAnalyticsCookie = { name: 'SovAnalytics', value: 'optout' };
 
+export const chartStorageKey = 'sovryn.charts';
+
 export const gasLimit = {
   [TxType.TRADE]: 1750000,
   [TxType.CLOSE_WITH_SWAP]: 1000000,


### PR DESCRIPTION
Implemented with localStorage for storing user drawings, which allows for around 5-10 sets of saved drawings/indicators per user.

If we find this does not offer enough storage we can investigate the full solution, but it requires a database and REST api to be setup.