### PR TITLE
Bug/1193 Missing Translations

### DIFF
--- a/src/app/containers/StakePage/components/CurrentStakes.tsx
+++ b/src/app/containers/StakePage/components/CurrentStakes.tsx
@@ -159,6 +159,9 @@ function AssetRow(props: AssetProps) {
   const now = new Date();
   const [weight, setWeight] = useState('');
   const locked = Number(props.item[1]) > Math.round(now.getTime() / 1e3); //check if date is locked
+  const stakingPeriod = Math.abs(
+    moment().diff(moment(new Date(parseInt(props.item[1]) * 1e3)), 'days'),
+  );
   const [votingPower, setVotingPower] = useState<number>(0 as any);
   const WEIGHT_FACTOR = useStaking_WEIGHT_FACTOR();
   const getWeight = useStaking_computeWeightByDate(
@@ -217,17 +220,7 @@ function AssetRow(props: AssetProps) {
         )}
       </td>
       <td className="tw-text-left tw-hidden lg:tw-table-cell tw-font-normal">
-        {locked && (
-          <>
-            {Math.abs(
-              moment().diff(
-                moment(new Date(parseInt(props.item[1]) * 1e3)),
-                'days',
-              ),
-            )}{' '}
-            days
-          </>
-        )}
+        {locked && t(translations.common.unit.day, { count: stakingPeriod })}
       </td>
       <td className="tw-text-left tw-hidden lg:tw-table-cell tw-font-normal">
         <p className="tw-m-0">

--- a/src/app/pages/MarginTradePage/components/TradeDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/TradeDialog/index.tsx
@@ -99,17 +99,23 @@ export function TradeDialog() {
       >
         <div className="tw-mw-320 tw-mx-auto">
           <h1 className="tw-mb-6 tw-text-white tw-text-center">
-            Review Transaction
+            {t(translations.marginTradePage.tradeDialog.title)}
           </h1>
           <div className="tw-text-sm tw-font-light tw-tracking-normal">
-            <LabelValuePair label="Trading Pair:" value={pair.name} />
             <LabelValuePair
-              label="Leverage:"
+              label={t(translations.marginTradePage.tradeDialog.pair)}
+              value={pair.name}
+            />
+            <LabelValuePair
+              label={t(translations.marginTradePage.tradeDialog.leverage)}
               value={<>{toNumberFormat(leverage)}x</>}
             />
-            <LabelValuePair label="Direction:" value={position} />
             <LabelValuePair
-              label="Collateral:"
+              label={t(translations.marginTradePage.tradeDialog.direction)}
+              value={position}
+            />
+            <LabelValuePair
+              label={t(translations.marginTradePage.tradeDialog.asset)}
               value={
                 <>
                   <LoadableValue
@@ -122,11 +128,15 @@ export function TradeDialog() {
               }
             />
             <LabelValuePair
-              label="Maintenance Margin:"
+              label={t(
+                translations.marginTradePage.tradeDialog.maintananceMargin,
+              )}
               value={<>{weiToNumberFormat(maintenanceMargin)}%</>}
             />
             <LabelValuePair
-              label="Est. Liquidation price:"
+              label={t(
+                translations.marginTradePage.tradeDialog.liquidationPrice,
+              )}
               value={
                 <>
                   <LiquidationPrice
@@ -160,7 +170,10 @@ export function TradeDialog() {
           {/*  />*/}
           {/*</FormGroup>*/}
 
-          <FormGroup label="Approx. Position Entry Price:" className="tw-mt-8">
+          <FormGroup
+            label={t(translations.marginTradePage.tradeDialog.entryPrice)}
+            className="tw-mt-8"
+          >
             <div className="tw-input-wrapper readonly">
               <div className="tw-input">
                 <PricePrediction

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1326,6 +1326,16 @@
         "short": "Short"
       }
     },
+    "tradeDialog": {
+      "title": "Review Transaction",
+      "pair": "Trading Pair:",
+      "leverage": "Leverage:",
+      "asset": "Collateral:",
+      "direction": "Direction:",
+      "maintananceMargin": "Maintenance Margin:",
+      "liquidationPrice": "Est. Liquidation Price:",
+      "entryPrice": "Approx. Position Entry Price:"
+    },
     "openPositions": "Open Positions",
     "tradingHistory": "Trading History"
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -14,7 +14,11 @@
     "deposit": "Deposit",
     "withdraw": "Withdraw",
     "availableBalance": "Available Balance:",
-    "maintenance": "Under Maintenance"
+    "maintenance": "Under Maintenance",
+    "unit": {
+      "day": "{{count}} day",
+      "day_plural": "{{count}} days"
+    }
   },
   "global": {
     "liquidationPrice": "Liquidation Price",


### PR DESCRIPTION
Resolves #1193

Connect Wallet dialog needs to be translated, but is provided by @sovryn/wallet as far as I know.
May need a new issue at the appropriate place.

Yield Farm & Lend > History > Action
Still needs to be translated, currently just passed as is from the Endpoint.

SwapPage "Pair" is already translated
Lending "SOV Rewards" doesn't exist anymore.
  
 

