### PR TITLE
Bug/1193 missing translations

### DIFF
--- a/src/app/components/StakingDateSelector/index.tsx
+++ b/src/app/components/StakingDateSelector/index.tsx
@@ -11,6 +11,8 @@ import { Text } from '@blueprintjs/core/lib/esm/components/text/text';
 import { MenuItem } from '@blueprintjs/core/lib/esm/components/menu/menuItem';
 import { ItemRenderer } from '@blueprintjs/select/lib/esm/common/itemRenderer';
 import { ItemPredicate } from '@blueprintjs/select/lib/esm/common/predicate';
+import { useTranslation } from 'react-i18next';
+import { translations } from '../../../locales/i18n';
 
 const maxPeriods = 78;
 
@@ -32,6 +34,7 @@ interface Props {
 }
 
 export function StakingDateSelector(props: Props) {
+  const { t } = useTranslation();
   const onItemSelect = (item: { key: number }) => props.onClick(item.key / 1e3);
   const [dates, setDates] = useState<Date[]>([]);
   const [currentYearDates, setCurrenYearDates] = useState<any>([]);
@@ -165,7 +168,9 @@ export function StakingDateSelector(props: Props) {
     <>
       {avaliableYears.length > 0 && (
         <label className="tw-block tw-mt-8 tw-text-theme-white tw-text-md tw-font-medium tw-mb-2">
-          {props.delegate ? <>Choose delegate period:</> : <>Select Year:</>}
+          {props.delegate
+            ? t(translations.stake.dateSelector.selectDelegate)
+            : t(translations.stake.dateSelector.selectYear)}
         </label>
       )}
       <div className="tw-flex tw-flex-row">
@@ -226,7 +231,7 @@ export function StakingDateSelector(props: Props) {
       </div>
       {avaliableYears.length <= 0 && (
         <p className="tw-block tw-mt-4 tw-text-red tw-text-sm tw-font-medium tw-mb-2">
-          No avaliable dates.
+          {t(translations.stake.dateSelector.noneAvailable)}
         </p>
       )}
     </>

--- a/src/app/containers/StakePage/components/CurrentStakes.tsx
+++ b/src/app/containers/StakePage/components/CurrentStakes.tsx
@@ -159,6 +159,9 @@ function AssetRow(props: AssetProps) {
   const now = new Date();
   const [weight, setWeight] = useState('');
   const locked = Number(props.item[1]) > Math.round(now.getTime() / 1e3); //check if date is locked
+  const stakingPeriod = Math.abs(
+    moment().diff(moment(new Date(parseInt(props.item[1]) * 1e3)), 'days'),
+  );
   const [votingPower, setVotingPower] = useState<number>(0 as any);
   const WEIGHT_FACTOR = useStaking_WEIGHT_FACTOR();
   const getWeight = useStaking_computeWeightByDate(
@@ -217,17 +220,7 @@ function AssetRow(props: AssetProps) {
         )}
       </td>
       <td className="tw-text-left tw-hidden lg:tw-table-cell tw-font-normal">
-        {locked && (
-          <>
-            {Math.abs(
-              moment().diff(
-                moment(new Date(parseInt(props.item[1]) * 1e3)),
-                'days',
-              ),
-            )}{' '}
-            days
-          </>
-        )}
+        {locked && t(translations.common.unit.day, { count: stakingPeriod })}
       </td>
       <td className="tw-text-left tw-hidden lg:tw-table-cell tw-font-normal">
         <p className="tw-m-0">

--- a/src/app/containers/StakePage/components/StakeForm.tsx
+++ b/src/app/containers/StakePage/components/StakeForm.tsx
@@ -55,7 +55,7 @@ export function StakeForm(props: Props) {
               id="amount"
               type="text"
               value={props.amount}
-              placeholder="Enter amount"
+              placeholder={t(translations.stake.staking.amountPlaceholder)}
               onChange={e => props.onChangeAmount(handleNumberInput(e))}
             />
             <span className="tw-text-black tw-text-md tw-font-semibold tw-absolute tw-top-3 tw-right-5 tw-leading-4">

--- a/src/app/containers/StakePage/components/VestingContract.tsx
+++ b/src/app/containers/StakePage/components/VestingContract.tsx
@@ -160,10 +160,7 @@ export function VestingContract(props: Props) {
                   <img src={logoSvg} className="tw-ml-3 tw-mr-3" alt="sov" />
                 </div>
                 <div className="tw-text-sm tw-font-normal tw-hidden xl:tw-block tw-pl-3">
-                  {props.type === 'genesis' && 'Genesis SOV'}
-                  {props.type === 'origin' && 'Origin SOV'}
-                  {props.type === 'team' && 'Team SOV'}
-                  {props.type === 'reward' && 'Reward SOV'}
+                  {t(translations.stake.currentVests.assetType[props.type])}
                 </div>
               </div>
             </td>

--- a/src/app/pages/LiquidityMining/components/HistoryTable/TableRow/index.tsx
+++ b/src/app/pages/LiquidityMining/components/HistoryTable/TableRow/index.tsx
@@ -1,6 +1,8 @@
 import { DisplayDate } from 'app/components/ActiveUserLoanContainer/components/DisplayDate';
 import { LinkToExplorer } from 'app/components/LinkToExplorer';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { translations } from 'locales/i18n';
 import { LiquidityPool } from 'utils/models/liquidity-pool';
 import { TablePoolRenderer } from '../../../../../components/FinanceV2Components/TablePoolRenderer/index';
 import { TableTransactionStatus } from '../../../../../components/FinanceV2Components/TableTransactionStatus/index';
@@ -24,6 +26,8 @@ export const TableRow: React.FC<ITableRowProps> = ({
   txHash,
   asset,
 }) => {
+  const { t } = useTranslation();
+
   return (
     <tr className="tw-text-xs">
       <td>
@@ -35,7 +39,12 @@ export const TableRow: React.FC<ITableRowProps> = ({
           secondaryAsset={pool?.supplyAssets[1]?.asset}
         />
       </td>
-      <td>{type}</td>
+      <td>
+        {type === 'Added'
+          ? t(translations.liquidityMining.historyTable.txType.added)
+          : type === 'Removed' &&
+            t(translations.liquidityMining.historyTable.txType.removed)}
+      </td>
       <td>{asset}</td>
       <td>
         {amount} {asset}

--- a/src/app/pages/MarginTradePage/components/TradeDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/TradeDialog/index.tsx
@@ -99,17 +99,23 @@ export function TradeDialog() {
       >
         <div className="tw-mw-320 tw-mx-auto">
           <h1 className="tw-mb-6 tw-text-white tw-text-center">
-            Review Transaction
+            {t(translations.marginTradePage.tradeDialog.title)}
           </h1>
           <div className="tw-text-sm tw-font-light tw-tracking-normal">
-            <LabelValuePair label="Trading Pair:" value={pair.name} />
             <LabelValuePair
-              label="Leverage:"
+              label={t(translations.marginTradePage.tradeDialog.pair)}
+              value={pair.name}
+            />
+            <LabelValuePair
+              label={t(translations.marginTradePage.tradeDialog.leverage)}
               value={<>{toNumberFormat(leverage)}x</>}
             />
-            <LabelValuePair label="Direction:" value={position} />
             <LabelValuePair
-              label="Collateral:"
+              label={t(translations.marginTradePage.tradeDialog.direction)}
+              value={position}
+            />
+            <LabelValuePair
+              label={t(translations.marginTradePage.tradeDialog.asset)}
               value={
                 <>
                   <LoadableValue
@@ -122,11 +128,15 @@ export function TradeDialog() {
               }
             />
             <LabelValuePair
-              label="Maintenance Margin:"
+              label={t(
+                translations.marginTradePage.tradeDialog.maintananceMargin,
+              )}
               value={<>{weiToNumberFormat(maintenanceMargin)}%</>}
             />
             <LabelValuePair
-              label="Est. Liquidation price:"
+              label={t(
+                translations.marginTradePage.tradeDialog.liquidationPrice,
+              )}
               value={
                 <>
                   <LiquidationPrice
@@ -160,7 +170,10 @@ export function TradeDialog() {
           {/*  />*/}
           {/*</FormGroup>*/}
 
-          <FormGroup label="Approx. Position Entry Price:" className="tw-mt-8">
+          <FormGroup
+            label={t(translations.marginTradePage.tradeDialog.entryPrice)}
+            className="tw-mt-8"
+          >
             <div className="tw-input-wrapper readonly">
               <div className="tw-input">
                 <PricePrediction

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -483,6 +483,7 @@
     "staking": {
       "title": "Stake SOV",
       "amountToStake": "Amount to Stake",
+      "amountPlaceholder": "Enter amount",
       "votingPowerReceived": "Voting Power received"
     },
     "extending": {
@@ -544,6 +545,11 @@
       "confirm": "Confirm",
       "cancel": "Cancel",
       "withdraw": "Withdraw"
+    },
+    "dateSelector": {
+      "noneAvailable": "No available dates.",
+      "selectDelegate": "Choose delegate period:",
+      "selectYear": "Select Year:"
     },
     "loading": "Loading, please wait...",
     "nostake": "No stakes yet."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -14,7 +14,11 @@
     "deposit": "Deposit",
     "withdraw": "Withdraw",
     "availableBalance": "Available Balance:",
-    "maintenance": "Under Maintenance"
+    "maintenance": "Under Maintenance",
+    "unit": {
+      "day": "{{count}} day",
+      "day_plural": "{{count}} days"
+    }
   },
   "global": {
     "liquidationPrice": "Liquidation Price",
@@ -1325,6 +1329,16 @@
         "long": "Long",
         "short": "Short"
       }
+    },
+    "tradeDialog": {
+      "title": "Review Transaction",
+      "pair": "Trading Pair:",
+      "leverage": "Leverage:",
+      "asset": "Collateral:",
+      "direction": "Direction:",
+      "maintananceMargin": "Maintenance Margin:",
+      "liquidationPrice": "Est. Liquidation Price:",
+      "entryPrice": "Approx. Position Entry Price:"
     },
     "openPositions": "Open Positions",
     "tradingHistory": "Trading History"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1392,6 +1392,10 @@
         "liquidityAmount": "Liquidity Amount",
         "transactionHash": "Transaction Hash",
         "status": "Status"
+      },
+      "txType": {
+        "added": "Added",
+        "removed": "Removed"
       }
     },
     "rowTable": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -527,7 +527,13 @@
       "stakingPeriod": "Vesting Period",
       "unlockDate": "Unlock Date",
       "fees": "Fees Earned",
-      "noVestingContracts": "You don't have any vesting contracts."
+      "noVestingContracts": "You don't have any vesting contracts.",
+      "assetType": {
+        "genesis": "Genesis SOV",
+        "origin": "Origin SOV",
+        "team": "Team SOV",
+        "reward": "Reward SOV"
+      }
     },
     "actions": {
       "title": "Actions",

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -3,6 +3,12 @@ import { initReactI18next } from 'react-i18next';
 
 import LanguageDetector from 'i18next-browser-languagedetector';
 
+import moment from 'moment';
+// moment locale en is not needed, it's the default.
+import 'moment/locale/es';
+import 'moment/locale/pt-br';
+import 'moment/locale/fr';
+
 import en from './en/translation.json';
 import es from './es/translation.json';
 import pt_br from './pt_br/translation.json';
@@ -46,6 +52,11 @@ const convertLanguageJsonToObject = (obj: any, dict: {}, current?: string) => {
     }
   });
 };
+
+i18next.on('languageChanged', (lng: string) => {
+  moment.locale(lng);
+});
+
 export const i18n = i18next
   // pass the i18n instance to react-i18next.
   .use(initReactI18next)


### PR DESCRIPTION
Duplicate because of CI issues from Forking.

Resolves #1193

Connect Wallet dialog needs to be translated, but is provided by @sovryn/wallet as far as I know.
May need a new issue at the appropriate place.

Yield Farm & Lend > History > Action
Still needs to be translated, currently just passed as is from the Endpoint.

SwapPage "Pair" is already translated
Lending "SOV Rewards" doesn't exist anymore.