### PR TITLE
[Portfolio] Fix Fish token mainnet issues

### DIFF
--- a/src/app/components/UserAssets/FishDollarValue.tsx
+++ b/src/app/components/UserAssets/FishDollarValue.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { LoadableValue } from '../LoadableValue';
 import { numberToUSD } from '../../../utils/display-text/format';
-import { weiToFixed } from '../../../utils/blockchain/math-helpers';
+import { weiTo4 } from '../../../utils/blockchain/math-helpers';
 import { useGetFishDollarValue } from 'app/pages/OriginsLaunchpad/hooks/useGetFishDollarValue';
 
 interface Props {
@@ -10,11 +10,11 @@ interface Props {
 }
 
 export function FishDollarValue({ tokens }: Props) {
-  const fishDollarValue = useGetFishDollarValue(Number(tokens));
+  const { value, loading } = useGetFishDollarValue(Number(tokens));
   return (
     <LoadableValue
-      value={numberToUSD(Number(weiToFixed(fishDollarValue.value, 4)), 4)}
-      loading={fishDollarValue.loading}
+      value={numberToUSD(Number(weiTo4(value)), 4)}
+      loading={loading}
     />
   );
 }

--- a/src/app/components/UserAssets/FishDollarValue.tsx
+++ b/src/app/components/UserAssets/FishDollarValue.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { LoadableValue } from '../LoadableValue';
+import { numberToUSD } from '../../../utils/display-text/format';
+import { weiToFixed } from '../../../utils/blockchain/math-helpers';
+import { useGetFishDollarValue } from 'app/pages/OriginsLaunchpad/hooks/useGetFishDollarValue';
+
+interface Props {
+  tokens: string;
+}
+
+export function FishDollarValue({ tokens }: Props) {
+  const fishDollarValue = useGetFishDollarValue(Number(tokens));
+  return (
+    <LoadableValue
+      value={numberToUSD(Number(weiToFixed(fishDollarValue.value, 4)), 4)}
+      loading={fishDollarValue.loading}
+    />
+  );
+}

--- a/src/app/components/UserAssets/index.tsx
+++ b/src/app/components/UserAssets/index.tsx
@@ -35,7 +35,7 @@ import { Dialog } from '../../containers/Dialog';
 import { Button } from '../Button';
 import { discordInvite } from 'utils/classifiers';
 import { ConversionDialog } from './ConversionDialog';
-import { useGetFishDollarValue } from 'app/pages/OriginsLaunchpad/hooks/useGetFishDollarValue';
+import { FishDollarValue } from './FishDollarValue';
 
 export function UserAssets() {
   const { t } = useTranslation();
@@ -214,8 +214,6 @@ function AssetRow({ item, onFastBtc, onTransack, onConvert }: AssetProps) {
     get().catch();
   }, [item.asset, account, blockSync]);
 
-  const fishDollarValue = useGetFishDollarValue(Number(tokens));
-
   const dollarValue = useMemo(() => {
     if ([Asset.USDT, Asset.DOC].includes(item.asset)) {
       return tokens;
@@ -236,18 +234,14 @@ function AssetRow({ item, onFastBtc, onTransack, onConvert }: AssetProps) {
         <LoadableValue value={weiToNumberFormat(tokens, 4)} loading={loading} />
       </td>
       <td className="tw-text-right tw-hidden md:tw-table-cell">
-        <LoadableValue
-          value={numberToUSD(
-            Number(
-              weiToFixed(
-                item.asset === Asset.FISH ? fishDollarValue.value : dollarValue,
-                4,
-              ),
-            ),
-            4,
-          )}
-          loading={dollars.loading}
-        />
+        {item.asset === Asset.FISH ? (
+          <FishDollarValue tokens={tokens} />
+        ) : (
+          <LoadableValue
+            value={numberToUSD(Number(weiToFixed(dollarValue, 4)), 4)}
+            loading={dollars.loading}
+          />
+        )}
       </td>
       <td className="tw-text-right tw-hidden md:tw-table-cell">
         <div className="tw-w-full tw-flex tw-flex-row tw-space-x-4 tw-justify-end">

--- a/src/app/components/UserAssets/index.tsx
+++ b/src/app/components/UserAssets/index.tsx
@@ -9,7 +9,7 @@ import { bignumber } from 'mathjs';
 import { translations } from '../../../locales/i18n';
 import { ActionButton, ActionLink } from 'app/components/Form/ActionButton';
 import { getTokenContractName } from '../../../utils/blockchain/contract-helpers';
-import { weiToFixed } from '../../../utils/blockchain/math-helpers';
+import { weiTo4 } from '../../../utils/blockchain/math-helpers';
 import { AssetsDictionary } from '../../../utils/dictionaries/assets-dictionary';
 import { AssetDetails } from '../../../utils/models/asset-details';
 import { LoadableValue } from '../LoadableValue';
@@ -238,7 +238,7 @@ function AssetRow({ item, onFastBtc, onTransack, onConvert }: AssetProps) {
           <FishDollarValue tokens={tokens} />
         ) : (
           <LoadableValue
-            value={numberToUSD(Number(weiToFixed(dollarValue, 4)), 4)}
+            value={numberToUSD(Number(weiTo4(dollarValue)), 4)}
             loading={dollars.loading}
           />
         )}

--- a/src/utils/dictionaries/assets-dictionary.ts
+++ b/src/utils/dictionaries/assets-dictionary.ts
@@ -44,7 +44,7 @@ export class AssetsDictionary {
         Asset.CSOV,
         new AssetDetails(Asset.CSOV, 'C-SOV', 'C-Sovryn', 18, sovIcon),
       ],
-      [Asset.FISH, new AssetDetails(Asset.FISH, 'FISH', 'FISH', 18, fishIcon)],
+      //[Asset.FISH, new AssetDetails(Asset.FISH, 'FISH', 'FISH', 18, fishIcon)],
     ],
   );
 


### PR DESCRIPTION
Currently errors will be thrown when accessing Portfolio page with wallet engaged, when testing `development` branch on mainnet. This is due to the Fish token contract not being deployed on mainnet yet. This PR hides it from asset list in `src\utils\dictionaries\assets-dictionary.ts` and fixes an error due to a failed contract call via `useGetFishDollarValue()` hook. Simply removing the Fish asset from asset dictionary will not work as the `useGetFishDollarValue` hook is executed in `src\app\components\UserAssets\index.tsx` for all assets.

@creed-victor can you check if my solution (refactoring hook call into a custom component for Fish asset) could be implemented in a more elegant way?

Sample error:
![image](https://user-images.githubusercontent.com/765825/126663907-63b45ab8-d18e-471c-93e0-80c3008d64c5.png)
