### PR TITLE
Automatically update recalibration dates

### DIFF
--- a/src/app/pages/LendingPage/index.tsx
+++ b/src/app/pages/LendingPage/index.tsx
@@ -14,6 +14,9 @@ import { SkeletonRow } from '../../components/Skeleton/SkeletonRow';
 import { useAccount } from '../../hooks/useAccount';
 import CurrencyContainer from './components/CurrencyContainer';
 import { HistoryTable } from './components/HistoryTable';
+import { getNextMonday } from '../../../utils/dateHelpers';
+
+const date = getNextMonday();
 
 const LendingPage: React.FC = () => {
   const { t } = useTranslation();
@@ -35,7 +38,7 @@ const LendingPage: React.FC = () => {
             title="15K SOV"
             asset1={Asset.XUSD}
             message={t(translations.liquidityMining.recalibration, {
-              date: 'August 16',
+              date,
             })}
             linkUrl="https://www.sovryn.app/blog/sov-is-diving-into-the-lending-pools"
             linkText={t(translations.liquidityMining.lootDropLink)}

--- a/src/app/pages/LiquidityMining/index.tsx
+++ b/src/app/pages/LiquidityMining/index.tsx
@@ -22,8 +22,11 @@ import { useAccount } from '../../hooks/useAccount';
 import { AmmPoolsBanner } from './components/AmmPoolsBanner';
 import { HistoryTable } from './components/HistoryTable';
 import { MiningPool } from './components/MiningPool';
+import { getNextMonday } from '../../../utils/dateHelpers';
 
 const pools = LiquidityPoolDictionary.list();
+
+const date = getNextMonday();
 
 export function LiquidityMining() {
   const { t } = useTranslation();
@@ -57,7 +60,7 @@ export function LiquidityMining() {
             asset1={Asset.BNB}
             asset2={Asset.RBTC}
             message={t(translations.liquidityMining.recalibration, {
-              date: 'August 16',
+              date,
             })}
             linkUrl="https://www.sovryn.app/blog/bnb-btc-pool-is-live"
             linkText={t(translations.liquidityMining.lootDropLink)}
@@ -68,7 +71,7 @@ export function LiquidityMining() {
             asset1={Asset.XUSD}
             asset2={Asset.RBTC}
             message={t(translations.liquidityMining.recalibration, {
-              date: 'August 16',
+              date,
             })}
             linkUrl="https://www.sovryn.app/blog/xusd-go-brrrrr"
             linkText={t(translations.liquidityMining.lootDropLink)}
@@ -79,7 +82,7 @@ export function LiquidityMining() {
             asset1={Asset.SOV}
             asset2={Asset.RBTC}
             message={t(translations.liquidityMining.recalibration, {
-              date: 'August 16',
+              date,
             })}
             linkUrl="https://www.sovryn.app/blog/prepare-yourself-for-the-awakening"
             linkText={t(translations.liquidityMining.lootDropLink)}
@@ -90,7 +93,7 @@ export function LiquidityMining() {
             asset1={Asset.ETH}
             asset2={Asset.RBTC}
             message={t(translations.liquidityMining.recalibration, {
-              date: 'August 16',
+              date,
             })}
             linkUrl="https://www.sovryn.app/blog/over-1000-yield-for-eth-btc-lp-s"
             linkText={t(translations.liquidityMining.lootDropLink)}

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -1,0 +1,4 @@
+import moment from 'moment';
+
+export const getNextMonday = () =>
+  moment().startOf('week').add(1, 'week').day('monday').format('MMMM Do');

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -1,4 +1,4 @@
 import moment from 'moment';
 
 export const getNextMonday = () =>
-  moment().startOf('week').add(1, 'week').day('monday').format('MMMM Do');
+  moment().utc().startOf('week').add(1, 'week').day('monday').format('MMMM Do');


### PR DESCRIPTION
Updates recalibration date to August 23rd for Loot Drop promos (Lend and Yield Farm pages), and automates future changes to avoid us having to manually update them each Monday.