### PR TITLE
[StakePage] mitigate data reloads

### DIFF
--- a/src/app/containers/StakePage/components/CurrentStakes.tsx
+++ b/src/app/containers/StakePage/components/CurrentStakes.tsx
@@ -19,6 +19,7 @@ import { weiTo4 } from 'utils/blockchain/math-helpers';
 import { useStaking_computeWeightByDate } from '../../../hooks/staking/useStaking_computeWeightByDate';
 import { useMaintenance } from 'app/hooks/useMaintenance';
 import { Tooltip } from '@blueprintjs/core';
+import { Spinner } from '@blueprintjs/core';
 
 interface Stakes {
   onIncrease: (a: number, b: number) => void;
@@ -65,18 +66,21 @@ export function CurrentStakes(props: Stakes) {
         setStakeLoad(false);
       });
     }
+  }, [account, dates, stakes]);
 
-    return () => {
-      setStakesArray([]);
-    };
-  }, [account, getStakes.value, dates, stakes]);
   return (
     <>
       <p className="tw-font-semibold tw-text-lg tw-ml-6 tw-mb-4 tw-mt-6">
         {t(translations.stake.currentStakes.title)}
       </p>
       <div className="tw-bg-gray-light tw-rounded-b tw-shadow">
-        <div className="tw-rounded-lg tw-border tw-sovryn-table tw-pt-1 tw-pb-0 tw-pr-5 tw-pl-5 tw-mb-5 tw-max-h-96 tw-overflow-y-auto">
+        <div className="tw-sovryn-table tw-relative tw-rounded-lg tw-border tw-pt-1 tw-pb-0 tw-pr-5 tw-pl-5 tw-mb-5 tw-max-h-96 tw-overflow-y-auto">
+          {stakeLoad && (
+            <Spinner
+              size={20}
+              className="tw-absolute tw-top-4 tw-right-8 tw-text-white tw-z-index-100"
+            />
+          )}
           <StyledTable className="tw-w-full tw-text-white">
             <thead>
               <tr>
@@ -104,14 +108,7 @@ export function CurrentStakes(props: Stakes) {
               </tr>
             </thead>
             <tbody className="tw-mt-5 tw-font-montserrat tw-text-xs">
-              {stakeLoad && !stakesArray.length && (
-                <tr key="loading">
-                  <td colSpan={99} className="tw-text-center tw-font-normal">
-                    {t(translations.stake.loading)}
-                  </td>
-                </tr>
-              )}
-              {!stakeLoad && !stakesArray.length && (
+              {!stakesArray.length && (
                 <tr key="empty">
                   <td colSpan={99} className="tw-text-center tw-font-normal">
                     {t(translations.stake.nostake)}

--- a/src/app/hooks/useCacheCallWithValue.ts
+++ b/src/app/hooks/useCacheCallWithValue.ts
@@ -1,5 +1,5 @@
 import { useCacheCall } from './useCacheCall';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { ContractName } from '../../utils/types/contracts';
 import { Nullable } from '../../types';
 
@@ -21,14 +21,10 @@ export function useCacheCallWithValue<T = string>(
     ...args,
   );
 
-  const [fixedValue, setFixedValue] = useState(
-    value !== null ? value : defaultValue,
-  );
-
-  useEffect(() => {
-    setFixedValue(value !== null ? value : defaultValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, JSON.stringify(defaultValue)]);
+  const fixedValue = useMemo(() => (value !== null ? value : defaultValue), [
+    value,
+    defaultValue,
+  ]);
 
   return { value: fixedValue, loading, error };
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -183,7 +183,7 @@ export function fixNumber(amount: any) {
   return amount;
 }
 
-export function getUSDSum(array: any[]) {
+export function getUSDSum(array: number[]) {
   return array.reduce(function (sum, value) {
     return sum + value;
   }, 0);


### PR DESCRIPTION
Resolves https://taiga.sovryn.app/project/sovryn-light/issue/280

The many reloads stem from the syncing to the current network block index.

- replaced skeletons with spinners to reduce visual noise
- added spinner to CurrentStakes and removed clear table while loading
- fixed missing and wrong hook usages
- updated responsive behavior of the top 3 cards.