### PR TITLE
[Styling] remove :focus outline

### DIFF
--- a/src/styles/tailwindcss/base.css
+++ b/src/styles/tailwindcss/base.css
@@ -22,7 +22,7 @@
     @apply tw-font-body;
   }
 
-  :focus {
+  *:focus {
     outline: 0 !important;
     outline-offset: 0;
   }


### PR DESCRIPTION
Resolves https://taiga.sovryn.app/project/sovryn-light/issue/424

Added * to prevent auto removal on CSS cleanup on production build