### PR TITLE
Revert "hotfix: use wrbtc wrapper proxy for bnbs swaps"

### DIFF
--- a/src/app/containers/SwapFormContainer/index.tsx
+++ b/src/app/containers/SwapFormContainer/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
 import { translations } from 'locales/i18n';
 import { AssetRenderer } from 'app/components/AssetRenderer';
@@ -23,7 +23,10 @@ import { Input } from 'app/components/Form/Input';
 import { AvailableBalance } from '../../components/AvailableBalance';
 import { Arbitrage } from '../../components/Arbitrage/Arbitrage';
 import { useAccount } from '../../hooks/useAccount';
-import { getTokenContractName } from '../../../utils/blockchain/contract-helpers';
+import {
+  // getTokenContract,
+  getTokenContractName,
+} from '../../../utils/blockchain/contract-helpers';
 import { Sovryn } from '../../../utils/sovryn';
 import { contractReader } from '../../../utils/sovryn/contract-reader';
 import { ErrorBadge } from 'app/components/Form/ErrorBadge';
@@ -236,22 +239,15 @@ export function SwapFormContainer() {
     );
   }, [targetToken, sourceToken, minReturn, weiAmount]);
 
-  const tx = useMemo(
-    () =>
-      targetToken === Asset.RBTC ||
-      [sourceToken, targetToken].includes(Asset.BNB)
-        ? txPath
-        : txExternal,
-    [sourceToken, targetToken, txExternal, txPath],
-  );
+  const tx = useMemo(() => (targetToken === Asset.RBTC ? txPath : txExternal), [
+    targetToken,
+    txExternal,
+    txPath,
+  ]);
 
   const send = useCallback(
-    () =>
-      targetToken === Asset.RBTC ||
-      [sourceToken, targetToken].includes(Asset.BNB)
-        ? sendPath()
-        : sendExternal(),
-    [sourceToken, targetToken, sendPath, sendExternal],
+    () => (targetToken === Asset.RBTC ? sendPath() : sendExternal()),
+    [targetToken, sendPath, sendExternal],
   );
 
   return (

--- a/src/app/pages/LandingPage/index.tsx
+++ b/src/app/pages/LandingPage/index.tsx
@@ -144,9 +144,9 @@ export const LandingPage: React.FC<ILandingPageProps> = ({
           </div>
 
           <div className="tw-w-full md:tw-w-5/12">
-            {/*
+            {/* 
               Should un comment this and remove Banner once the sale is over.
-              <ArbitrageOpportunity />
+              <ArbitrageOpportunity /> 
             */}
             {/* <Banner
               title={t(translations.landingPage.banner.originsFish)}

--- a/src/app/pages/SpotTradingPage/components/TradeForm/index.tsx
+++ b/src/app/pages/SpotTradingPage/components/TradeForm/index.tsx
@@ -126,22 +126,15 @@ export function TradeForm() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => linkPairType && history.replace(location.pathname), []);
 
-  const tx = useMemo(
-    () =>
-      targetToken === Asset.RBTC ||
-      [sourceToken, targetToken].includes(Asset.BNB)
-        ? txPath
-        : txExternal,
-    [sourceToken, targetToken, txExternal, txPath],
-  );
+  const tx = useMemo(() => (targetToken === Asset.RBTC ? txPath : txExternal), [
+    targetToken,
+    txExternal,
+    txPath,
+  ]);
 
   const send = useCallback(
-    () =>
-      targetToken === Asset.RBTC ||
-      [sourceToken, targetToken].includes(Asset.BNB)
-        ? sendPath()
-        : sendExternal(),
-    [sourceToken, targetToken, sendPath, sendExternal],
+    () => (targetToken === Asset.RBTC ? sendPath() : sendExternal()),
+    [targetToken, sendPath, sendExternal],
   );
 
   return (


### PR DESCRIPTION
Reverts DistributedCollective/Sovryn-frontend#1755
Token is now enabled in smart-contracts and hotfix can be safely rollbacked to use swap external contract.