### PR TITLE
fix: lend pool profit display bug

### DIFF
--- a/src/app/pages/LendingPage/components/CurrencyContainer/UserLendingInfo.tsx
+++ b/src/app/pages/LendingPage/components/CurrencyContainer/UserLendingInfo.tsx
@@ -98,23 +98,28 @@ export const UserLendingInfo: React.FC<IUserLendingInfoProps> = ({
   const { useLM } = LendingPoolDictionary.get(asset);
 
   // this only gets used for LM enabled lending pools
-  const totalProfit = useMemo(() => {
-    return bignumber(tokenPrice)
-      .sub(checkpointPrice)
-      .mul(totalBalance)
-      .div(Math.pow(10, assetDecimals))
-      .add(profitCall)
-      .toFixed(0);
-  }, [profitCall, totalBalance, checkpointPrice, tokenPrice, assetDecimals]);
+  const totalProfit = useMemo(
+    () =>
+      bignumber(tokenPrice)
+        .sub(checkpointPrice)
+        .mul(totalBalance)
+        .div(Math.pow(10, assetDecimals))
+        .add(profitCall)
+        .toFixed(0),
+    [profitCall, totalBalance, checkpointPrice, tokenPrice, assetDecimals],
+  );
 
   // calculation for LM enabled lending pools uses totalProfit to get correct balance
-  const poolProfit = useMemo(() => {
-    return useLM ? totalProfit : profitCall;
-  }, [useLM, totalProfit, profitCall]);
+  const poolProfit = useMemo(() => (useLM ? totalProfit : profitCall), [
+    useLM,
+    totalProfit,
+    profitCall,
+  ]);
 
-  const balance = useMemo(() => {
-    return bignumber(balanceCall).minus(poolProfit).toString();
-  }, [balanceCall, poolProfit]);
+  const balance = useMemo(
+    () => bignumber(balanceCall).minus(poolProfit).toString(),
+    [balanceCall, poolProfit],
+  );
 
   useEffect(() => {
     if (balance !== '0') {


### PR DESCRIPTION
https://taiga.sovryn.app/project/sovryn-light/issue/173

Steps to replicate/test: 

* deposit funds into a lending pool, wait for some time to get profit
* calculate expected amount to withdraw: initial deposit + profit
* click withdraw and check that value in amount input is correct when 100% button is clicked in withdraw modal
* confirm withdraw tx and verify that value received is the value that was shown in amount input from previous step

If fix is not working, amount shown in withdraw modal will not match calculated value from step 2.

When testing, multiple lend pools should be reviewed using above steps, to ensure all work as expected.