### PR TITLE
fix: liquality wallet crashing dapp on disconnection by bumping @sovr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@redux-saga/delay-p": "1.1.2",
     "@reduxjs/toolkit": "1.5.1",
     "@rsksmart/rsk3": "0.3.4",
-    "@sovryn/react-wallet": "2.0.3",
+    "@sovryn/react-wallet": "2.0.4",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,10 +3341,10 @@
   dependencies:
     debug "^4.3.1"
 
-"@sovryn/react-wallet@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.0.3.tgz#c0f71d0e67868d38830d4100fcdc2462d8578b9a"
-  integrity sha512-jmZ47B3q72YwBI7tLhoSSxIKe0YH9hjqBGL2Pgt+o/fmSqPK1sqzYDaOJso98fbwnzRQj5Mh06ZWi7b0Giy6DA==
+"@sovryn/react-wallet@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.0.4.tgz#061da6b5beb02b3e91d966dc0717b7af1fe1aa7c"
+  integrity sha512-ttiFcV2PUMsCQSod9QW/n3HGssPkTqINS/4U5qmjXWdsoh3X3rsJgp6N4wv/3k/I4z0apqPs9g3rWv/Mpi9Mtg==
   dependencies:
     "@blueprintjs/core" "^3.44.2"
     "@hookstate/core" "^3.0.6"


### PR DESCRIPTION
from #1799 

https://taiga.sovryn.app/project/sovryn-light/issue/523

Steps to replicate:

connect liquality wallet to dapp
click disconnect button on wallet connection element
Errors will be thrown in the browser console and the page will go blank if fix not working.