### PR TITLE
changed testnet amm converter addresses

### DIFF
--- a/src/utils/blockchain/contracts.testnet.ts
+++ b/src/utils/blockchain/contracts.testnet.ts
@@ -111,7 +111,7 @@ export const contracts = {
   //   blockNumber: 1218721,
   // },
   MOC_amm: {
-    address: '0xF110caE6F634859cc6337EC3E203Aa78837F3D60',
+    address: '0x55E405334f5Ecb888965d471310bdFADC6A09f3b',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -156,7 +156,7 @@ export const contracts = {
     blockNumber: 1406290,
   },
   XUSD_amm: {
-    address: '0x0ff080d232Ab50B78E79295aa2B1fae95ff297c9',
+    address: '0xbe5c68F7B5FF5bb65671AedD692fC4174Cba29cf',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -186,7 +186,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   ETH_amm: {
-    address: '0x7fE5EcE50E75a0a3fb596ba7a74FcF3216878A2D',
+    address: '0xe7Fd55E7463fdC0a8EBf8C172B707A710020869d',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -201,7 +201,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   BNBS_amm: {
-    address: '0x5DEf61E87f38f631BF22C2C405de7F51eD0FEEEC',
+    address: '0xDE642E5cb539488401E819493c31E516aCd00b61',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -279,7 +279,7 @@ export const contracts = {
     blockNumber: 1606431,
   },
   SOV_amm: {
-    address: '0xFF5f65c66F381695A250774Dd2510FB85799d8fC',
+    address: '0xBa55EF856AC5520Bf768b637D0c8cA4006b742DC',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -321,7 +321,7 @@ export const contracts = {
     abi: FISHTokenAbi,
   },
   FISH_amm: {
-    address: '0x209A87Bb9B44834a05d16c9e2271c24Ae4C4224d',
+    address: '0x682dD67d04E4C2BbCB8DD6F7DCf4393dDC3d54b0',
     abi: LiquidityPoolV1Converter,
   },
   FISH_staking: {

--- a/src/utils/blockchain/contracts.testnet.ts
+++ b/src/utils/blockchain/contracts.testnet.ts
@@ -111,7 +111,7 @@ export const contracts = {
   //   blockNumber: 1218721,
   // },
   MOC_amm: {
-    address: '0xE378A270Ad891e57A29C22ab17Eb31796199812e',
+    address: '0x3D18E1EC60c9725494252A835593aa90Da777E15',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -156,7 +156,7 @@ export const contracts = {
     blockNumber: 1406290,
   },
   XUSD_amm: {
-    address: '0xAD6Aef3B717Cf90754b83344B113Fe6271932E0e',
+    address: '0x9a1aE300b23F4C676186e6d417ac586889aAfF42',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -186,7 +186,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   ETH_amm: {
-    address: '0xedeA3dC4e27E41ebf1BBb5354aa96945D204e521',
+    address: '0x4c493276E14791472633B55aaD82E49D28540bC6',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -201,7 +201,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   BNBS_amm: {
-    address: '0xbA76111FAC4dAa5Fa75d69EF8cEd45C58bBd85e2',
+    address: '0xA8D7FDd2f67273F178EFe731d4becd38E2A94E11',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -279,7 +279,7 @@ export const contracts = {
     blockNumber: 1606431,
   },
   SOV_amm: {
-    address: '0x9CEDA5a9351A2511470b6171aFA9047197322b83',
+    address: '0xaBAABc2191A23D6Bb2cfa973892062c131cb7647',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -321,7 +321,7 @@ export const contracts = {
     abi: FISHTokenAbi,
   },
   FISH_amm: {
-    address: '0x5D1909DBDEff454d200Eb8Ce759581d367dB9943',
+    address: '0x5871040a14331c0f7AB5390A3Df16D271b0936ef',
     abi: LiquidityPoolV1Converter,
   },
   FISH_staking: {

--- a/src/utils/blockchain/contracts.testnet.ts
+++ b/src/utils/blockchain/contracts.testnet.ts
@@ -111,7 +111,7 @@ export const contracts = {
   //   blockNumber: 1218721,
   // },
   MOC_amm: {
-    address: '0x55E405334f5Ecb888965d471310bdFADC6A09f3b',
+    address: '0xE378A270Ad891e57A29C22ab17Eb31796199812e',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -156,7 +156,7 @@ export const contracts = {
     blockNumber: 1406290,
   },
   XUSD_amm: {
-    address: '0xbe5c68F7B5FF5bb65671AedD692fC4174Cba29cf',
+    address: '0xAD6Aef3B717Cf90754b83344B113Fe6271932E0e',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -186,7 +186,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   ETH_amm: {
-    address: '0xe7Fd55E7463fdC0a8EBf8C172B707A710020869d',
+    address: '0xedeA3dC4e27E41ebf1BBb5354aa96945D204e521',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -201,7 +201,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   BNBS_amm: {
-    address: '0xDE642E5cb539488401E819493c31E516aCd00b61',
+    address: '0xbA76111FAC4dAa5Fa75d69EF8cEd45C58bBd85e2',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -279,7 +279,7 @@ export const contracts = {
     blockNumber: 1606431,
   },
   SOV_amm: {
-    address: '0xBa55EF856AC5520Bf768b637D0c8cA4006b742DC',
+    address: '0x9CEDA5a9351A2511470b6171aFA9047197322b83',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -321,7 +321,7 @@ export const contracts = {
     abi: FISHTokenAbi,
   },
   FISH_amm: {
-    address: '0x682dD67d04E4C2BbCB8DD6F7DCf4393dDC3d54b0',
+    address: '0x5D1909DBDEff454d200Eb8Ce759581d367dB9943',
     abi: LiquidityPoolV1Converter,
   },
   FISH_staking: {

--- a/src/utils/blockchain/contracts.testnet.ts
+++ b/src/utils/blockchain/contracts.testnet.ts
@@ -111,7 +111,7 @@ export const contracts = {
   //   blockNumber: 1218721,
   // },
   MOC_amm: {
-    address: '0x478133b66B54e55bfA46b1182e274b5cCE47C60E',
+    address: '0xF110caE6F634859cc6337EC3E203Aa78837F3D60',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -156,7 +156,7 @@ export const contracts = {
     blockNumber: 1406290,
   },
   XUSD_amm: {
-    address: '0x169B7A8Fc9615797e118B464b4fF1f594Dcad7a4',
+    address: '0x0ff080d232Ab50B78E79295aa2B1fae95ff297c9',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -186,7 +186,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   ETH_amm: {
-    address: '0xf46DC974edD1754D4815AaE44Ab4542fF39B898D',
+    address: '0x7fE5EcE50E75a0a3fb596ba7a74FcF3216878A2D',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -201,7 +201,7 @@ export const contracts = {
   //   blockNumber: 1406290,
   // },
   BNBS_amm: {
-    address: '0x4F87d545B6E747433a80a6AA0dbEc962478aB271',
+    address: '0x5DEf61E87f38f631BF22C2C405de7F51eD0FEEEC',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -279,7 +279,7 @@ export const contracts = {
     blockNumber: 1606431,
   },
   SOV_amm: {
-    address: '0x1Cecc8B488abcF9A0932E54328dD51980cbe86Ea',
+    address: '0xFF5f65c66F381695A250774Dd2510FB85799d8fC',
     abi: LiquidityPoolV1Converter,
     blockNumber: 1218833,
   },
@@ -321,7 +321,7 @@ export const contracts = {
     abi: FISHTokenAbi,
   },
   FISH_amm: {
-    address: '0x179caA42B5024ec1C3D8513A262fC9986F565295',
+    address: '0x209A87Bb9B44834a05d16c9e2271c24Ae4C4224d',
     abi: LiquidityPoolV1Converter,
   },
   FISH_staking: {


### PR DESCRIPTION
Changed addresses of SOV/RBTC, XUSD/RBTC, FISH/RBTC, BNBS/RBTC, ETHS/RBTC & MOC/RBTC AMM pool converter addresses.

QA:
- deposit to AMM pools (Yield Farm)
- withdraw from AMM pools
- make swaps using these pools
- open trade positions
- add margin to position
- close position 