### PR TITLE
fix: reward SOV shown for non-LM Lend pools

### DIFF
--- a/src/app/pages/LiquidityMining/hooks/useLiquidityMining_getPoolId.ts
+++ b/src/app/pages/LiquidityMining/hooks/useLiquidityMining_getPoolId.ts
@@ -4,7 +4,7 @@ export function useLiquidityMining_getPoolId(poolToken: string) {
   return useCacheCallWithValue(
     'liquidityMiningProxy',
     'getPoolId',
-    '0',
+    '',
     poolToken,
   );
 }


### PR DESCRIPTION
https://taiga.sovryn.app/project/sovryn-light/issue/665

Bug fix for cases where user has accrued reward SOV for other liquidity mining enabled pools, and rewards appear for non-LM enabled pools such as RBTC. Issue is caused by failed call to `liquidityMiningProxy.getPoolId()`, which was using default value of 0 (thereby causing reward SOV value to be retrieved for another pool).