### PR TITLE
fix: bump gas limit for unlend, ensure lend/unlend respects gas limits

### DIFF
--- a/src/app/hooks/lending/useLending_burn.ts
+++ b/src/app/hooks/lending/useLending_burn.ts
@@ -3,6 +3,7 @@ import { getLendingContractName } from 'utils/blockchain/contract-helpers';
 import { useSendContractTx } from '../useSendContractTx';
 import { useAccount } from '../useAccount';
 import { TxType } from '../../../store/global/transactions-store/types';
+import { gasLimit } from 'utils/classifiers';
 import { LendingPoolDictionary } from '../../../utils/dictionaries/lending-pool-dictionary';
 
 export function useLending_burn(asset: Asset, weiAmount: string) {
@@ -15,7 +16,7 @@ export function useLending_burn(asset: Asset, weiAmount: string) {
     send: (nonce?: number, approveTx?: string | null) => {
       send(
         [account, weiAmount, LendingPoolDictionary.get(asset).useLM],
-        { from: account, nonce },
+        { from: account, nonce, gas: gasLimit[TxType.UNLEND] },
         { approveTransactionHash: approveTx, type: TxType.UNLEND },
       );
     },

--- a/src/app/hooks/lending/useLending_mint.ts
+++ b/src/app/hooks/lending/useLending_mint.ts
@@ -3,6 +3,7 @@ import { getLendingContractName } from 'utils/blockchain/contract-helpers';
 import { TxType } from 'store/global/transactions-store/types';
 import { useSendContractTx } from '../useSendContractTx';
 import { useAccount } from '../useAccount';
+import { gasLimit } from 'utils/classifiers';
 import { LendingPoolDictionary } from '../../../utils/dictionaries/lending-pool-dictionary';
 
 export function useLending_mint(asset: Asset, weiAmount: string) {
@@ -18,7 +19,12 @@ export function useLending_mint(asset: Asset, weiAmount: string) {
       asset === Asset.RBTC
         ? send(
             [account, useLM],
-            { from: account, value: weiAmount, nonce },
+            {
+              from: account,
+              value: weiAmount,
+              nonce,
+              gas: gasLimit[TxType.LEND],
+            },
             {
               approveTransactionHash: approveTx,
               type: TxType.LEND,
@@ -26,7 +32,7 @@ export function useLending_mint(asset: Asset, weiAmount: string) {
           )
         : send(
             [account, weiAmount, useLM],
-            { from: account, nonce },
+            { from: account, nonce, gas: gasLimit[TxType.LEND] },
             {
               approveTransactionHash: approveTx,
               type: TxType.LEND,

--- a/src/utils/classifiers.ts
+++ b/src/utils/classifiers.ts
@@ -56,7 +56,7 @@ export const gasLimit = {
   [TxType.BORROW]: 1500000,
   [TxType.CONVERT_BY_PATH]: 750000,
   [TxType.LEND]: 300000,
-  [TxType.UNLEND]: 350000,
+  [TxType.UNLEND]: 450000,
   [TxType.SALE_BUY_SOV]: 260000,
   [TxType.SOV_REIMBURSE]: 100000,
   [TxType.SOV_CONVERT]: 2700000,


### PR DESCRIPTION
Currently HW wallet users are experiencing gas limit issues when withdrawing assets from Lend pools. This PR bumps the gas limit and forces the limit to be respected when creating the tx.