### PR TITLE
allow ethereum HD derivation paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@redux-saga/delay-p": "1.1.2",
     "@reduxjs/toolkit": "1.5.1",
     "@rsksmart/rsk3": "0.3.4",
-    "@sovryn/react-wallet": "2.0.4",
+    "@sovryn/react-wallet": "2.1.2",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3008,6 +3008,17 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
+"@metamask/eth-sig-util@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-4.0.0.tgz#11553ba06de0d1352332c1bde28c8edd00e0dcf6"
+  integrity sha512-LczOjjxY4A7XYloxzyxJIHONELmUxVZncpOLoClpEcTiebiVdM46KRPYXGuULro9oNNR2xdVx3yoKiQjdfWmoA==
+  dependencies:
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-util "^6.2.1"
+    ethjs-util "^0.1.6"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+
 "@metamask/safe-event-emitter@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
@@ -3334,23 +3345,24 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sovryn/common@^1.0.16":
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/@sovryn/common/-/common-1.0.16.tgz#969776aa26fec8b8554af957063739537a1b5942"
-  integrity sha512-htBu/sws5FosbOOv9tCCvz4fMxMe5MIHG7K5ZT3EQVS7VKayFloJ4JAucCtAADYyjEXM8RNY5dQJlHKe78zmdg==
+"@sovryn/common@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@sovryn/common/-/common-2.1.1.tgz#c47728bdbe0c95abf0b4791c40e23257dd7f795a"
+  integrity sha512-B1AI5v6iNC8NQIQK9A6feRh7Pl+Wv8gcVli3/ss56B39DU8whIPl1HTkp9Rdo31o/xEfqm+roBskvHRe5HXRRQ==
   dependencies:
     debug "^4.3.1"
 
-"@sovryn/react-wallet@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.0.4.tgz#061da6b5beb02b3e91d966dc0717b7af1fe1aa7c"
-  integrity sha512-ttiFcV2PUMsCQSod9QW/n3HGssPkTqINS/4U5qmjXWdsoh3X3rsJgp6N4wv/3k/I4z0apqPs9g3rWv/Mpi9Mtg==
+"@sovryn/react-wallet@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.1.2.tgz#17384b4332b9922468c0e4a9ed6ee0acfa0643d6"
+  integrity sha512-Igx0uMffjHvCaoASBcGG7o1LwGRF/AZkc729yrAvGJWzR2M34MxdksQiiCL8dZnDseD67PII1HRanL01kQa1vQ==
   dependencies:
     "@blueprintjs/core" "^3.44.2"
     "@hookstate/core" "^3.0.6"
-    "@sovryn/wallet" "^2.0.3"
+    "@sovryn/wallet" "^2.1.2"
     "@types/classnames" "^2.2.11"
     "@types/react-copy-to-clipboard" "^5.0.0"
+    caniuse-lite "^1.0.30001287"
     classnames "^2.2.6"
     detect-browser "^5.2.0"
     ethereumjs-util "^7.0.9"
@@ -3364,19 +3376,21 @@
     web3 "^1.3.6"
     web3-core "^1.3.6"
 
-"@sovryn/wallet@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.0.3.tgz#2a22641ed1c56578b335b1c7fdce9b7576dd84cc"
-  integrity sha512-7GTqZa7dLwwvXJn4cXT31xeY8ee8lvIJb+QiZYkvxqLd5A35lIlNIEFNQsE67aOV/tQGs8EWMSX6JJBYMZGsog==
+"@sovryn/wallet@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.1.2.tgz#a80dc3d6caed214b878a69db1dac912cf0c5e151"
+  integrity sha512-F6qHfdraS1x+hnZ3SQ2ZGDeYff1kgWirPWNlB8LifTeYyEzGgrRx1LZTxcMlY2FB8wGblrszEpeMmPosH3+Mag==
   dependencies:
     "@ledgerhq/hw-app-eth" "^5.53.0"
     "@ledgerhq/hw-transport" "^5.51.1"
     "@ledgerhq/hw-transport-u2f" "^5.36.0-deprecated"
     "@ledgerhq/hw-transport-web-ble" "^5.51.1"
     "@ledgerhq/hw-transport-webusb" "^5.53.1"
+    "@metamask/eth-sig-util" "^4.0.0"
     "@portis/web3" "^3.0.8"
-    "@sovryn/common" "^1.0.16"
+    "@sovryn/common" "^2.1.1"
     "@trezor/rollout" "^1.0.7"
+    "@types/w3c-web-usb" "^1.0.5"
     "@walletconnect/web3-provider" "^1.5.2"
     ethereumjs-common "1.5.2"
     ethereumjs-tx "2.1.2"
@@ -5014,6 +5028,11 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@types/w3c-web-usb@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.5.tgz#90284d17f35de981670c85d29053ae8b88fa5543"
+  integrity sha512-dYolx2XWesl1TMu+1BjtjU6eC6c2zZ2VDKhjU4f/mtR3+UBfMW6h1tPCQt7leY5Y8JBg0Fe/mMnoDMkPPNX9sw==
 
 "@types/webpack-env@1.15.1":
   version "1.15.1"
@@ -7884,6 +7903,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
   integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
+caniuse-lite@^1.0.30001287:
+  version "1.0.30001287"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001287.tgz#5fab6a46ab9e47146d5dd35abfe47beaf8073c71"
+  integrity sha512-4udbs9bc0hfNrcje++AxBuc6PfLNHwh3PO9kbwnfCQWyqtlzg3py0YgFu8jyRTTo85VAz4U+VLxSlID09vNtWA==
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -10707,7 +10731,7 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
-"ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
   dependencies:
@@ -10804,7 +10828,7 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.1.1, ethereumjs-util@^5.1.2, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^6.0.0:
+ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
   integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
@@ -10941,7 +10965,7 @@ ethjs-unit@0.1.6, ethjs-unit@^0.1.6:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3:
+ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
@@ -22385,10 +22409,20 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tweetnacl-util@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
+  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This PR updates `@sovyn/react-wallet` which allows users to use ethereum derivation paths when connecting their ledger or trezor wallets. 

QA:
- open dapp, click "connect wallet", select "hardware" and then "ledger" in dialog
- choose "ethereum - xxxxx" derivation path from the list
- connect wallet
- make swaps, trades, etc to confirm transactions can be submitted
- repeat with trezor

Note: when using etheureum HD derivation path with ledger,  make sure to have Ethereum app opened in ledger device (instead of rsk app)