### PR TITLE
fix(bridge): reset USDT allowance to 0

### DIFF
--- a/src/app/pages/BridgeDepositPage/saga.ts
+++ b/src/app/pages/BridgeDepositPage/saga.ts
@@ -30,6 +30,7 @@ import { bignumber } from 'mathjs';
 import { ethers } from 'ethers';
 import { TxType } from 'store/global/transactions-store/types';
 import { gasLimit } from 'utils/classifiers';
+import { CrossBridgeAsset } from './types/cross-bridge-asset';
 
 const { log } = debug('bridge/saga.ts');
 
@@ -113,20 +114,46 @@ function* approveTransfer() {
     yield take(actions.approveTokens.type);
     const payload = yield select(selectBridgeDepositPage);
 
-    const nonce = yield call(
-      [bridgeNetwork, bridgeNetwork.nonce],
-      payload.chain,
-    );
+    let nonce = yield call([bridgeNetwork, bridgeNetwork.nonce], payload.chain);
 
     const bridge = BridgeDictionary.get(
       payload.chain as any,
       payload.targetChain,
     ) as BridgeModel;
     const asset = bridge.getAsset(payload.sourceAsset as any) as AssetModel;
-
-    console.log('approveTransfer: asset is', asset);
-
+    let useCustomGas = false;
     try {
+      // Tether (USDT) on ETH requires allowance to be set to 0 before adding more allowance:
+      if (
+        payload.chain === Chain.ETH &&
+        payload.sourceAsset === CrossBridgeAsset.USDT
+      ) {
+        const allowance = yield call(
+          [bridgeNetwork, bridgeNetwork.allowance],
+          payload.chain as any,
+          asset,
+          getSpenderAddress(payload.chain as any, bridge, asset) ||
+            bridge.bridgeContractAddress,
+        );
+
+        if (allowance !== '0') {
+          const data = bridgeNetwork.approveData(
+            payload.chain,
+            asset,
+            getSpenderAddress(payload.chain as any, bridge, asset) ||
+              bridge.bridgeContractAddress,
+            '0',
+          );
+          yield call([bridgeNetwork, bridgeNetwork.send], payload.chain, {
+            to: asset.tokenContractAddress,
+            nonce,
+            data,
+          });
+          nonce += 1;
+          useCustomGas = true;
+        }
+      }
+
       const data = bridgeNetwork.approveData(
         payload.chain,
         asset,
@@ -141,6 +168,7 @@ function* approveTransfer() {
           to: asset.tokenContractAddress,
           nonce,
           data,
+          gasLimit: useCustomGas ? 60000 : undefined,
         },
       );
 


### PR DESCRIPTION
Resets USDT allowance to 0 before requesting approval for more (ethereum side)

QA:
- Open portfolio
- Select XUSD -> Deposit
- Choose USDT as deposit token
- Enter amount you want to deposit (do not use entire balance)
- Confirm transaction for approval tx
- Cancel second transaction (the deposit one)
- Repeat it for second time but do not cancel transaction anymore and with higher amount than first time: you should be asked to confirm 3 transactions (2 approval, 1 deposit)
- Repeat it for third time: you should be asked to confirm 2 transactions (1 approval, 1 deposit)

Try same thing for any other token than USDT too - you should be asked to confirm 2 transactions and not 3 for other ones.