### PR TITLE
fix: switch placement of 'buy' & 'deposit' buttons

### DIFF
--- a/src/app/components/UserAssets/index.tsx
+++ b/src/app/components/UserAssets/index.tsx
@@ -284,12 +284,12 @@ const AssetRow: React.FC<IAssetRowProps> = ({
         <div className="tw-w-full tw-flex tw-flex-row tw-space-x-4 tw-justify-end">
           {item.asset === Asset.RBTC && (
             <>
-              <Link to="/fast-btc/deposit">
-                <span>{t(translations.common.deposit)}</span>
-              </Link>
               <button className={styles.actionLink} onClick={onTransack}>
                 {t(translations.userAssets.actions.buy)}
               </button>
+              <Link to="/fast-btc/deposit">
+                <span>{t(translations.common.deposit)}</span>
+              </Link>
               <Link to="/fast-btc/withdraw">
                 <span>{t(translations.common.withdraw)}</span>
               </Link>


### PR DESCRIPTION
Simple change to switch position of Buy and Deposit buttons for RBTC asset on Portfolio page:
https://discord.com/channels/729675474665603133/750376232771780608/938565395219087371
![image](https://user-images.githubusercontent.com/765825/152402023-4cdc961d-24a6-464c-84c0-24f2755a3d2c.png)

ACs:
- Ensure that the buttons on Portfolio page for RBTC are in following order: "Buy", "Deposit", "Withdraw"