### PR TITLE
fix: hide unsupported wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@redux-saga/delay-p": "1.1.2",
     "@reduxjs/toolkit": "1.5.1",
     "@rsksmart/rsk3": "0.3.4",
-    "@sovryn/react-wallet": "2.1.2",
+    "@sovryn/react-wallet": "2.1.4",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "10.0.1",

--- a/src/app/containers/WalletProvider/index.tsx
+++ b/src/app/containers/WalletProvider/index.tsx
@@ -1,9 +1,3 @@
-/**
- *
- * WalletConnector
- *
- */
-
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import crypto from 'crypto';
@@ -36,7 +30,6 @@ import { currentChainId } from '../../../utils/classifiers';
 import { actions } from './slice';
 import { useEvent } from 'app/hooks/useAnalytics';
 import { selectWalletProvider } from './selectors';
-import { useLocation } from 'react-router-dom';
 
 interface Props {
   children: React.ReactNode;
@@ -58,15 +51,13 @@ export function WalletProvider(props: Props) {
   const requestDialog = useSelector(selectRequestDialogState);
   const { bridgeChainId } = useSelector(selectWalletProvider);
   const dispatch = useDispatch();
-  const location = useLocation();
 
   useEffect(() => {
     dispatch(actions.testTransactions());
   }, [dispatch]);
 
   const options = useMemo(() => {
-    const isCrossChain = location.pathname.startsWith('/cross-chain');
-    const customChain = bridgeChainId !== null && isCrossChain;
+    const customChain = bridgeChainId !== null;
     return {
       showWrongNetworkRibbon: false,
       remember: !customChain,
@@ -74,7 +65,7 @@ export function WalletProvider(props: Props) {
       enableSoftwareWallet:
         process.env.REACT_APP_ENABLE_SOFTWARE_WALLET === 'true',
     };
-  }, [bridgeChainId, location]);
+  }, [bridgeChainId]);
 
   return (
     <SovrynWallet options={options}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3377,10 +3377,10 @@
   dependencies:
     debug "^4.3.1"
 
-"@sovryn/react-wallet@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.1.2.tgz#17384b4332b9922468c0e4a9ed6ee0acfa0643d6"
-  integrity sha512-Igx0uMffjHvCaoASBcGG7o1LwGRF/AZkc729yrAvGJWzR2M34MxdksQiiCL8dZnDseD67PII1HRanL01kQa1vQ==
+"@sovryn/react-wallet@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.1.4.tgz#7c7838987f89357f855e7d3152b8080e55724ef9"
+  integrity sha512-ZcnBnlhg+4Z9tzB2gDs8eDW6wT23VtBu9d/u7ow8ws3RyA/0ekhMYILO50LWr8MRFSs3PIVgpRrQU8YEbqyUpA==
   dependencies:
     "@blueprintjs/core" "^3.44.2"
     "@hookstate/core" "^3.0.6"


### PR DESCRIPTION
https://sovryn.monday.com/boards/2218344956/pulses/2243609008

Hides unsupported wallets for chain.

QA in perpetuals page, click connect wallet and verify that "Mobile" (Wallet Connect) and "Portis" in Browser screen is missing.
In homepage, click connect wallet and verify that "Mobile" and "Portis" are there.