### PR TITLE
Feat/liquality cross chain deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@redux-saga/delay-p": "1.1.2",
     "@reduxjs/toolkit": "1.5.1",
     "@rsksmart/rsk3": "0.3.4",
-    "@sovryn/react-wallet": "2.1.2",
+    "@sovryn/react-wallet": "2.2.0",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@redux-saga/delay-p": "1.1.2",
     "@reduxjs/toolkit": "1.5.1",
     "@rsksmart/rsk3": "0.3.4",
-    "@sovryn/react-wallet": "2.2.0",
+    "@sovryn/react-wallet": "2.2.1",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "5.1.1",
     "@testing-library/react": "10.0.1",

--- a/src/app/pages/BridgeDepositPage/components/ReturnToPortfolio/index.tsx
+++ b/src/app/pages/BridgeDepositPage/components/ReturnToPortfolio/index.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useWalletContext } from '@sovryn/react-wallet';
-import { isWeb3Wallet } from '@sovryn/wallet';
+import { isWeb3Wallet, InjectedWalletProvider } from '@sovryn/wallet';
 
 import { Chain } from 'types';
 import { actions } from '../../slice';
@@ -34,6 +34,16 @@ export const ReturnToPortfolio: React.FC = () => {
   }, [dispatch]);
 
   const { wallet, connected, connect } = useWalletContext();
+
+  const chainId = useMemo(() => {
+    if (isWeb3Wallet(wallet.providerType!)) {
+      const provider = InjectedWalletProvider.getProvider(currentChainId);
+      if (provider) {
+        return parseInt(provider.chainId);
+      }
+    }
+    return parseInt(wallet?.chainId.toString());
+  }, [wallet.providerType, wallet?.chainId]);
 
   const handleNetworkSwitch = useCallback(() => {
     dispatch(actions.selectSourceNetwork(Chain.RSK));
@@ -67,7 +77,7 @@ export const ReturnToPortfolio: React.FC = () => {
           />
         </>
       )}
-      {connected && wallet.chainId !== currentChainId && (
+      {connected && chainId !== currentChainId && (
         <>
           <SelectBox onClick={noop}>
             <img
@@ -98,7 +108,7 @@ export const ReturnToPortfolio: React.FC = () => {
         </>
       )}
 
-      {wallet.chainId === currentChainId && (
+      {chainId === currentChainId && (
         <>
           <SelectBox onClick={noop}>
             <img

--- a/src/app/pages/BridgeDepositPage/saga.ts
+++ b/src/app/pages/BridgeDepositPage/saga.ts
@@ -169,6 +169,7 @@ function* approveTransfer() {
           nonce,
           data,
           gasLimit: useCustomGas ? 60000 : undefined,
+          chainId: Number(getBridgeChainId(payload.chain)),
         },
       );
 
@@ -271,6 +272,7 @@ function* confirmTransfer() {
             nonce !== undefined
               ? gasLimit[TxType.CROSS_CHAIN_DEPOSIT]
               : undefined,
+          chainId: Number(getBridgeChainId(payload.chain)),
         },
       );
 

--- a/src/app/pages/BridgeDepositPage/utils/bridge-network.ts
+++ b/src/app/pages/BridgeDepositPage/utils/bridge-network.ts
@@ -14,6 +14,7 @@ import erc20Abi from 'utils/blockchain/abi/erc20.json';
 import mAssetAbi from 'utils/blockchain/abi/BabelFish_MassetAbi.json';
 import bridgeAbi from 'utils/blockchain/abi/BridgeAbi.json';
 import { CrossBridgeAsset } from '../types/cross-bridge-asset';
+import { currentChainId } from 'utils/classifiers';
 
 interface MultiCallData {
   address: string;
@@ -198,7 +199,7 @@ export class BridgeNetwork {
       gasPrice: tx.gasPrice.toString(),
       nonce: Number(tx.nonce),
       gasLimit: tx.gasLimit.toString(),
-      chainId: walletService.chainId,
+      chainId: tx.chainId || currentChainId,
     });
 
     if (isWeb3Wallet(walletService.providerType as ProviderType)) {

--- a/src/app/pages/BridgeWithdrawPage/saga.ts
+++ b/src/app/pages/BridgeWithdrawPage/saga.ts
@@ -24,6 +24,7 @@ import { BridgeModel } from '../BridgeDepositPage/types/bridge-model';
 import { AssetModel } from '../BridgeDepositPage/types/asset-model';
 import {
   getBridgeChain,
+  getBridgeChainId,
   getSupportedBridgeChainIds,
 } from '../BridgeDepositPage/utils/helpers';
 import { bridgeNetwork } from '../BridgeDepositPage/utils/bridge-network';
@@ -132,6 +133,7 @@ function* approveTransfer() {
           to: asset.tokenContractAddress,
           nonce,
           data,
+          chainId: Number(getBridgeChainId(payload.chain)),
         },
       );
 
@@ -236,6 +238,7 @@ function* confirmTransfer() {
             nonce !== undefined
               ? gasLimit[TxType.CROSS_CHAIN_WITHDRAW]
               : undefined,
+          chainId: Number(getBridgeChainId(payload.chain)),
         },
       );
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,7 +4,7 @@ import type { Decimal } from 'decimal.js';
 import { currentChainId } from './classifiers';
 import { gas } from './blockchain/gas-price';
 import { Asset } from '../types';
-import { ProviderType } from '@sovryn/wallet';
+import { ProviderType, InjectedWalletProvider } from '@sovryn/wallet';
 import { walletService } from '@sovryn/react-wallet';
 import { CachedAssetRate } from 'app/containers/WalletProvider/types';
 import { numberFromWei } from './blockchain/math-helpers';
@@ -174,7 +174,7 @@ export function detectWeb3Wallet() {
   switch (walletService.providerType) {
     default:
     case ProviderType.WEB3:
-      const { ethereum } = window;
+      const ethereum = InjectedWalletProvider.getProvider(currentChainId);
       if (ethereum) {
         if (ethereum.isLiquality) return 'liquality';
         if (ethereum.isNiftyWallet) return 'nifty';

--- a/src/utils/sovryn/contract-writer.ts
+++ b/src/utils/sovryn/contract-writer.ts
@@ -20,7 +20,7 @@ import {
 import { Nullable } from '../../types';
 import { gas } from '../blockchain/gas-price';
 import { transferAmount } from '../blockchain/transfer-approve-amount';
-import { MIN_GAS } from 'utils/classifiers';
+import { currentChainId, MIN_GAS } from 'utils/classifiers';
 
 import erc20Abi from 'utils/blockchain/abi/erc20.json';
 
@@ -200,7 +200,7 @@ class ContractWriter {
               gasPrice: gas.get(),
               nonce,
               gasLimit: String(gasLimit),
-              chainId: walletService.chainId,
+              chainId: options?.chainId || currentChainId,
             },
           );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,14 +3347,14 @@
   dependencies:
     debug "^4.3.1"
 
-"@sovryn/react-wallet@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.2.0.tgz#6646e9a724ffd79741819c7d50379a41f469d409"
-  integrity sha512-rMKDsHA6kZwk5zCAXiiPLsfAtE6YP5QwLIbGxENWyogXCWoXc9hqrOdvU2/jnOLM8jLFwlx2Pmp5yew1OIvDKg==
+"@sovryn/react-wallet@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.2.1.tgz#53a0437e7c77f280dacbff6091c6d1059acad82a"
+  integrity sha512-tRjbmW1FW+TE4KL3wYhTlEJTq+d3iJycV4IXBwuzwoq6oxqFoP1PsTCx4PoTDGBPM3gNa8hErPjPchASLL++MA==
   dependencies:
     "@blueprintjs/core" "^3.44.2"
     "@hookstate/core" "^3.0.6"
-    "@sovryn/wallet" "^2.2.0"
+    "@sovryn/wallet" "^2.2.1"
     "@types/classnames" "^2.2.11"
     "@types/react-copy-to-clipboard" "^5.0.0"
     caniuse-lite "^1.0.30001287"
@@ -3371,10 +3371,10 @@
     web3 "^1.3.6"
     web3-core "^1.3.6"
 
-"@sovryn/wallet@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.2.0.tgz#89465216676e8f58e8e23910ed30920990e1f808"
-  integrity sha512-sE0arnIaBVsPgvaBf7x57WnfwIxEc0g5gOfjDXJH5CP4O2Lo6DOQTTqKuelsHiZUjybYhFvTPmBzGRcbg8qcSw==
+"@sovryn/wallet@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.2.1.tgz#c6bc2eeffcd70e7f4b26a7a4c66fd65664b48b64"
+  integrity sha512-tYA6PnQg0kMLDDN0KuOTeK4mJeBoCJjy2sK8zU//vkhMUs5R2lrqf2855kRGvtx/Z/lBwYKmdJLrJG78q5wj0g==
   dependencies:
     "@ledgerhq/hw-app-eth" "^5.53.0"
     "@ledgerhq/hw-transport" "^5.51.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,14 +3347,14 @@
   dependencies:
     debug "^4.3.1"
 
-"@sovryn/react-wallet@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.1.2.tgz#17384b4332b9922468c0e4a9ed6ee0acfa0643d6"
-  integrity sha512-Igx0uMffjHvCaoASBcGG7o1LwGRF/AZkc729yrAvGJWzR2M34MxdksQiiCL8dZnDseD67PII1HRanL01kQa1vQ==
+"@sovryn/react-wallet@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.2.0.tgz#6646e9a724ffd79741819c7d50379a41f469d409"
+  integrity sha512-rMKDsHA6kZwk5zCAXiiPLsfAtE6YP5QwLIbGxENWyogXCWoXc9hqrOdvU2/jnOLM8jLFwlx2Pmp5yew1OIvDKg==
   dependencies:
     "@blueprintjs/core" "^3.44.2"
     "@hookstate/core" "^3.0.6"
-    "@sovryn/wallet" "^2.1.2"
+    "@sovryn/wallet" "^2.2.0"
     "@types/classnames" "^2.2.11"
     "@types/react-copy-to-clipboard" "^5.0.0"
     caniuse-lite "^1.0.30001287"
@@ -3371,10 +3371,10 @@
     web3 "^1.3.6"
     web3-core "^1.3.6"
 
-"@sovryn/wallet@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.1.2.tgz#a80dc3d6caed214b878a69db1dac912cf0c5e151"
-  integrity sha512-F6qHfdraS1x+hnZ3SQ2ZGDeYff1kgWirPWNlB8LifTeYyEzGgrRx1LZTxcMlY2FB8wGblrszEpeMmPosH3+Mag==
+"@sovryn/wallet@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.2.0.tgz#89465216676e8f58e8e23910ed30920990e1f808"
+  integrity sha512-sE0arnIaBVsPgvaBf7x57WnfwIxEc0g5gOfjDXJH5CP4O2Lo6DOQTTqKuelsHiZUjybYhFvTPmBzGRcbg8qcSw==
   dependencies:
     "@ledgerhq/hw-app-eth" "^5.53.0"
     "@ledgerhq/hw-transport" "^5.51.1"


### PR DESCRIPTION
This feature allows users to use dapp without manually switching networks in Liquality wallet extension (with exception to mainnet <-> testnet switches)

QA:
part 1:
- make Liquality wallet your default wallet
- make sure it's set to mainnet mode
- set dapp network setting (in Liquality wallet) to other network than rsk (arbitrum for example)
- open website and connect wallet
- verify that you see modal asking liquality wallet to switch to rsk mainnet (should also say you are on rsk testnet)
- switch liquality wallet to testnet mod, refresh page and connect again
- verify that there is no modal asking to switch networks
- verify you can swap your testnet tokens

part 2:
- connect liquality wallet and open portfolio page
- click "deposit" on sov, xusd, eths or bnbs
- complete deposit flow
- verify that you was not asked to switch networks for the entire flow

part 3:
- connect liquality wallet and open portfolio page
- click "withdraw" on sov, xusd, eths or bnbs
- complete withdraw flow

part 4:
- make same tests with metamask/nifty browser wallets and trezor / ledger hardware wallets
- verify these wallets works as before:
- when nifty/metamask is in wrong network - should show modal asking to switch
- swapping works
- cross-bridge deposit works (dapp should ask to switch networks)
- cross-bridge withdraw works (withdraws doesn't require to switch network, it's always on rsk)