### PR TITLE
[Perpetuals] add TradingChart custom colors, UTC timezone and 5min candles

### DIFF
--- a/public/charting_library_custom.css
+++ b/public/charting_library_custom.css
@@ -1,0 +1,4 @@
+/* remove toolbar background color */
+.theme-dark:root .group-wWM3zP_M- {
+  background-color: transparent !important;
+}

--- a/src/app/pages/PerpetualPage/PerpetualPageContainer.tsx
+++ b/src/app/pages/PerpetualPage/PerpetualPageContainer.tsx
@@ -16,7 +16,7 @@ import {
   PerpetualPairDictionary,
   PerpetualPairType,
 } from '../../../utils/dictionaries/perpetual-pair-dictionary';
-import { Theme, TradingChart } from './components/TradingChart';
+import { TradingChart } from './components/TradingChart';
 import { OpenPositionsTable } from './components/OpenPositionsTable';
 import { useIsConnected } from '../../hooks/useAccount';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -137,11 +137,7 @@ export const PerpetualPageContainer: React.FC = () => {
               className={'tw-max-w-full xl:tw-w-3/5 2xl:tw-w-2/5'}
               hasCustomHeight
             >
-              <TradingChart
-                symbol={pair.chartSymbol}
-                theme={Theme.DARK}
-                hasCustomDimensions
-              />
+              <TradingChart symbol={pair.chartSymbol} hasCustomDimensions />
             </DataCard>
             <DataCard
               className="xl:tw-hidden 2xl:tw-flex xl:tw-w-1/5"

--- a/src/app/pages/PerpetualPage/components/TradingChart/helpers.ts
+++ b/src/app/pages/PerpetualPage/components/TradingChart/helpers.ts
@@ -13,6 +13,7 @@ import { ApolloClient } from '@apollo/client';
 // https://github.com/tradingview/charting_library/wiki/JS-Api/f62fddae9ad1923b9f4c97dbbde1e62ff437b924#onreadycallback
 export const supportedResolutions = [
   '1',
+  '5',
   '10',
   '15',
   '30',
@@ -131,6 +132,7 @@ export const symbolMap = PerpetualPairDictionary.list().reduce(
 
 export const resolutionMap: { [key: string]: CandleDuration } = {
   '1': CandleDuration.M_1,
+  '5': CandleDuration.M_1,
   '10': CandleDuration.M_1,
   '15': CandleDuration.M_15,
   '30': CandleDuration.M_15,

--- a/src/app/pages/PerpetualPage/components/TradingChart/index.tsx
+++ b/src/app/pages/PerpetualPage/components/TradingChart/index.tsx
@@ -11,6 +11,8 @@ import classNames from 'classnames';
 import {
   widget,
   IChartingLibraryWidget,
+  ChartingLibraryWidgetOptions,
+  Timezone,
 } from '@distributedcollective/charting-library/src/charting_library/charting_library.min';
 
 import { Skeleton } from '../../../../components/PageSkeleton';
@@ -19,21 +21,37 @@ import storage from './storage';
 import { noop } from '../../../../constants';
 import { Nullable } from '../../../../../types';
 import { useApolloClient } from '@apollo/client';
+import dayjs from 'dayjs';
 
-export enum Theme {
-  LIGHT = 'Light',
-  DARK = 'Dark',
-}
+export type TradingChartColors = {
+  text: string;
+  background: string;
+  linesX: string;
+  linesY: string;
+  crosshair: string;
+  long: string;
+  short: string;
+};
+
+export const TRADING_CHART_DEFAULT_COLORS: TradingChartColors = {
+  text: '#e8e8e8', // sov-white
+  background: '#222222', // gray-2.5
+  linesX: '#343434', // gray-4
+  linesY: '#343434', // gray-4
+  crosshair: '#5c5c5c', // gray-5
+  long: '#17C3B2', // trade-long
+  short: '#D74E09', // trade-short
+};
 
 export type TradingChartProps = {
   symbol: string;
-  theme?: Theme;
+  colors?: TradingChartColors;
   hasCustomDimensions?: boolean;
 };
 
 export const TradingChart: React.FC<TradingChartProps> = ({
   symbol,
-  theme = Theme.DARK,
+  colors = TRADING_CHART_DEFAULT_COLORS,
   hasCustomDimensions = false,
 }) => {
   const [hasCharts, setHasCharts] = useState(false);
@@ -43,7 +61,7 @@ export const TradingChart: React.FC<TradingChartProps> = ({
   useEffect(() => {
     try {
       // full list of widget config options here: https://github.com/tradingview/charting_library/wiki/Widget-Constructor/cf26598509d8bba6dc95c5fe8208caa5e8474827
-      const widgetOptions: any = {
+      const widgetOptions: ChartingLibraryWidgetOptions = {
         debug: false,
         symbol,
         datafeed: datafeed(client),
@@ -66,19 +84,28 @@ export const TradingChart: React.FC<TradingChartProps> = ({
           'volume_force_overlay',
         ],
         overrides: {
-          'paneProperties.background': '#000000',
-          'paneProperties.vertGridProperties.color': '#454545',
-          'paneProperties.horzGridProperties.color': '#454545',
+          'paneProperties.background': colors.background,
+          'paneProperties.vertGridProperties.color': colors.linesY,
+          'paneProperties.horzGridProperties.color': colors.linesX,
+          'paneProperties.crossHairProperties.color': colors.crosshair,
+          'scalesProperties.textColor': colors.text,
+          'scalesProperties.backgroundColor': colors.background,
           'symbolWatermarkProperties.transparency': 90,
-          'scalesProperties.textColor': '#AAA',
-          'scalesProperties.backgroundColor': '#121214',
           'paneProperties.topMargin': 15,
           'paneProperties.bottomMargin': 10,
+
+          'mainSeriesProperties.candleStyle.upColor': colors.long,
+          'mainSeriesProperties.candleStyle.downColor': colors.short,
+          'mainSeriesProperties.candleStyle.borderUpColor': colors.long,
+          'mainSeriesProperties.candleStyle.borderDownColor': colors.short,
+          'mainSeriesProperties.candleStyle.wickUpColor': colors.long,
+          'mainSeriesProperties.candleStyle.wickDownColor': colors.short,
         },
+        custom_css_url: '/charting_library_custom.css',
+
         autosize: true,
-        toolbar_bg: '#000000',
-        header_bg: '#000000',
-        theme,
+        toolbar_bg: colors.background,
+        theme: 'Dark',
         time_frames: [
           { text: '1d', resolution: '15', description: '1d', title: '1d' },
           { text: '3d', resolution: '30', description: '3d', title: '3d' },
@@ -88,6 +115,7 @@ export const TradingChart: React.FC<TradingChartProps> = ({
           // { text: '1y', resolution: '1W', description: '1y', title: '1y' },
           { text: '5y', resolution: '1W', description: '5y', title: '5y' },
         ],
+        timezone: 'Etc/UTC',
       };
 
       const myChart = new widget(widgetOptions);
@@ -118,10 +146,7 @@ export const TradingChart: React.FC<TradingChartProps> = ({
 
   return (
     <div
-      className={classNames(
-        'tw-w-full tw-h-full tw-flex tw-rounded tw-overflow-hidden',
-        hasCharts && 'tw-border',
-      )}
+      className="tw-w-full tw-h-full tw-flex tw-rounded tw-overflow-hidden"
       style={
         hasCustomDimensions ? undefined : { minWidth: 270, minHeight: 500 }
       }

--- a/src/app/pages/PerpetualPage/components/TradingChart/storage.ts
+++ b/src/app/pages/PerpetualPage/components/TradingChart/storage.ts
@@ -9,6 +9,7 @@
 import { v4 as uuid } from 'uuid';
 import { local } from 'utils/storage';
 import { chartStorageKey } from 'utils/classifiers';
+import { IExternalSaveLoadAdapter } from '@distributedcollective/charting-library/src/charting_library/charting_library.min';
 
 type StoredCharts = {
   [id: string]: ChartData;
@@ -42,7 +43,7 @@ const setJSON = (key: string, obj: any) =>
 
 // Details on implemented methods can be found here:
 // https://github.com/tradingview/charting_library/wiki/Saving-and-Loading-Charts/0918ee9f5215ebd5a06d0ec9ee2bdffbd5822342#api-handlers
-const tradingChartStorage = {
+const tradingChartStorage: IExternalSaveLoadAdapter = {
   /** Chart Layout (drawing) methods **/
   getAllCharts: () => Promise.resolve(Object.values(getJSON(LAYOUT_KEY)) || []),
 


### PR DESCRIPTION
Resolves https://sovryn.monday.com/boards/2218344956/pulses/2350572876

Also fixed the used colors, changed the background to #222222, because of upcoming changes.
Added 5min candles and changed the default timezone to UTC same as Recent Trades 