### PR TITLE
Add a : in the backend login text

### DIFF
--- a/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
@@ -79,7 +79,7 @@ export const NotificationSettingsDialog: React.FC<INotificationSettingsDialogPro
   const getToken = async () => {
     if (!account) return;
     const timestamp = new Date();
-    const message = `Login to backend on ${timestamp}`;
+    const message = `Login to backend on: ${timestamp}`;
     const { data: alreadyUser } = await axios.get(
       url + 'user/isUser/' + account,
     );


### PR DESCRIPTION
We changed the backend a bit so that the text to login to backend is [ ANY MESSAGE ]: [ DATE ]

This is so we can reuse this logic and make the text as specific/descriptive as we want and as long as the date is within a minute of now, the authentication should pass