### PR TITLE
feat: use fallback RSK-RPC-Nodes

### DIFF
--- a/src/app/containers/WalletProvider/slice.ts
+++ b/src/app/containers/WalletProvider/slice.ts
@@ -58,6 +58,8 @@ const walletProviderSlice = createSlice({
       state.networkId = action.payload.networkId;
     },
 
+    connectionError() {},
+
     disconnect() {},
 
     disconnected(state) {

--- a/src/utils/classifiers.ts
+++ b/src/utils/classifiers.ts
@@ -23,8 +23,8 @@ export const blockExplorers = {
 };
 
 export const rpcNodes = {
-  30: 'https://mainnet.sovryn.app/rpc',
-  31: 'https://testnet.sovryn.app/rpc',
+  30: ['https://mainnet.sovryn.app/rpc', 'https://public-node.rsk.co/'],
+  31: ['https://testnet.sovryn.app/rpc', 'https://public-node.testnet.rsk.co/'],
 };
 
 export const databaseRpcNodes = {


### PR DESCRIPTION
If mainnet.sovryn.app (or testnet.sovryn.app depending on network) is unavailable (DNS or AWS problems for example), use public rsk nodes provided by IOVLabs as fallback.