### PR TITLE
Fetch data for all the pairs

### DIFF
--- a/src/app/pages/PerpetualPage/components/AccountBalanceCard/index.tsx
+++ b/src/app/pages/PerpetualPage/components/AccountBalanceCard/index.tsx
@@ -8,11 +8,15 @@ import { PerpetualPageModals } from '../../types';
 import { selectPerpetualPage } from '../../selectors';
 import { getCollateralName } from '../../utils/renderUtils';
 import { PerpetualQueriesContext } from '../../contexts/PerpetualQueriesContext';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 export const AccountBalanceCard: React.FC = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const { availableBalance } = useContext(PerpetualQueriesContext);
+
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { availableBalance } = perpetuals[currentPairId];
 
   const { collateral } = useSelector(selectPerpetualPage);
   const collateralAsset = useMemo(() => getCollateralName(collateral), [

--- a/src/app/pages/PerpetualPage/components/ClosePositionDialog/components/SlippageFormStep.tsx
+++ b/src/app/pages/PerpetualPage/components/ClosePositionDialog/components/SlippageFormStep.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../../../utils/dictionaries/perpetual-pair-dictionary';
 import { PerpetualQueriesContext } from 'app/pages/PerpetualPage/contexts/PerpetualQueriesContext';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from 'app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId';
 
 const { calculateSlippagePrice } = perpUtils;
 
@@ -26,7 +27,9 @@ export const SlippageFormStep: TransitionStep<ClosePositionDialogStep> = ({
 }) => {
   const { t } = useTranslation();
 
-  const { averagePrice } = useContext(PerpetualQueriesContext);
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { averagePrice } = perpetuals[currentPairId];
 
   const { changedTrade, onChange } = useContext(ClosePositionDialogContext);
 

--- a/src/app/pages/PerpetualPage/components/ClosePositionDialog/components/TradeFormStep.tsx
+++ b/src/app/pages/PerpetualPage/components/ClosePositionDialog/components/TradeFormStep.tsx
@@ -37,6 +37,7 @@ import { ActionDialogSubmitButton } from '../../ActionDialogSubmitButton';
 import { usePerpetual_isTradingInMaintenance } from 'app/pages/PerpetualPage/hooks/usePerpetual_isTradingInMaintenance';
 import { selectPerpetualPage } from '../../../selectors';
 import { perpMath, perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from 'app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId';
 
 const { roundToLot } = perpMath;
 const { getTraderPnLInCC, calculateSlippagePrice } = perpUtils;
@@ -47,6 +48,9 @@ export const TradeFormStep: TransitionStep<ClosePositionDialogStep> = ({
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+
   const {
     ammState,
     traderState,
@@ -55,7 +59,7 @@ export const TradeFormStep: TransitionStep<ClosePositionDialogStep> = ({
     lotSize,
     lotPrecision,
     availableBalance,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const { useMetaTransactions } = useSelector(selectPerpetualPage);
 

--- a/src/app/pages/PerpetualPage/components/ContractDetails/index.tsx
+++ b/src/app/pages/PerpetualPage/components/ContractDetails/index.tsx
@@ -12,6 +12,7 @@ import { Asset } from '../../../../../types';
 import { Tooltip } from '@blueprintjs/core';
 import { PerpetualQueriesContext } from '../../contexts/PerpetualQueriesContext';
 import { LayoutMenu } from '../LayoutMenu';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 type ContractDetailsProps = {
   pair: PerpetualPair;
@@ -25,7 +26,9 @@ export const ContractDetails: React.FC<ContractDetailsProps> = ({
   const { t } = useTranslation();
   const data = usePerpetual_ContractDetails(pair.pairType);
 
-  const { lotPrecision } = useContext(PerpetualQueriesContext);
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { lotPrecision } = perpetuals[currentPairId];
 
   const collateralAsset = useMemo(() => getCollateralName(collateral), [
     collateral,

--- a/src/app/pages/PerpetualPage/components/EditLeverageDialog/index.tsx
+++ b/src/app/pages/PerpetualPage/components/EditLeverageDialog/index.tsx
@@ -35,6 +35,7 @@ import { ActionDialogSubmitButton } from '../ActionDialogSubmitButton';
 import { usePerpetual_isTradingInMaintenance } from '../../hooks/usePerpetual_isTradingInMaintenance';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 const {
   getRequiredMarginCollateral,
@@ -54,12 +55,14 @@ export const EditLeverageDialog: React.FC = () => {
 
   const inMaintenance = usePerpetual_isTradingInMaintenance();
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
   const {
     ammState,
     traderState,
     perpetualParameters: perpParameters,
     availableBalance,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const trade = useMemo(
     () => (isPerpetualTrade(modalOptions) ? modalOptions : undefined),

--- a/src/app/pages/PerpetualPage/components/EditMarginDialog/index.tsx
+++ b/src/app/pages/PerpetualPage/components/EditMarginDialog/index.tsx
@@ -32,6 +32,7 @@ import { ActionDialogSubmitButton } from '../ActionDialogSubmitButton';
 import { usePerpetual_isTradingInMaintenance } from '../../hooks/usePerpetual_isTradingInMaintenance';
 import { getCollateralName } from '../../utils/renderUtils';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 const {
   calculateApproxLiquidationPrice,
@@ -57,12 +58,14 @@ export const EditMarginDialog: React.FC = () => {
 
   const inMaintenance = usePerpetual_isTradingInMaintenance();
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
   const {
     ammState,
     traderState,
     perpetualParameters: perpParameters,
     availableBalance,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const collateralName = useMemo(() => getCollateralName(collateral), [
     collateral,

--- a/src/app/pages/PerpetualPage/components/EditPositionSizeDialog/components/SlippageFormStep.tsx
+++ b/src/app/pages/PerpetualPage/components/EditPositionSizeDialog/components/SlippageFormStep.tsx
@@ -18,6 +18,7 @@ import { TradingPosition } from '../../../../../../types/trading-position';
 import { AssetValueMode } from '../../../../../components/AssetValue/types';
 import { PerpetualQueriesContext } from 'app/pages/PerpetualPage/contexts/PerpetualQueriesContext';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from 'app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId';
 
 const { calculateSlippagePrice } = perpUtils;
 
@@ -26,7 +27,9 @@ export const SlippageFormStep: TransitionStep<EditPositionSizeDialogStep> = ({
 }) => {
   const { t } = useTranslation();
 
-  const { averagePrice } = useContext(PerpetualQueriesContext);
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { averagePrice } = perpetuals[currentPairId];
 
   const { changedTrade, onChange } = useContext(EditPositionSizeDialogContext);
 

--- a/src/app/pages/PerpetualPage/components/EditPositionSizeDialog/components/TradeFormStep.tsx
+++ b/src/app/pages/PerpetualPage/components/EditPositionSizeDialog/components/TradeFormStep.tsx
@@ -11,12 +11,16 @@ import { TradingPosition } from '../../../../../../types/trading-position';
 import { PerpetualTxMethods } from '../../TradeDialog/types';
 import { PerpetualQueriesContext } from 'app/pages/PerpetualPage/contexts/PerpetualQueriesContext';
 import { toWei } from '../../../../../../utils/blockchain/math-helpers';
+import { usePerpetual_getCurrentPairId } from 'app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId';
 
 export const TradeFormStep: TransitionStep<EditPositionSizeDialogStep> = ({
   changeTo,
 }) => {
   const dispatch = useDispatch();
-  const { traderState } = useContext(PerpetualQueriesContext);
+
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { traderState } = perpetuals[currentPairId];
 
   const { pairType, trade, changedTrade, onChange } = useContext(
     EditPositionSizeDialogContext,

--- a/src/app/pages/PerpetualPage/components/NewPositionCard/components/SlippageFormStep.tsx
+++ b/src/app/pages/PerpetualPage/components/NewPositionCard/components/SlippageFormStep.tsx
@@ -18,6 +18,7 @@ import {
 import { TradingPosition } from '../../../../../../types/trading-position';
 import { PerpetualQueriesContext } from 'app/pages/PerpetualPage/contexts/PerpetualQueriesContext';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from 'app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId';
 
 const {
   calculateSlippagePrice,
@@ -30,12 +31,14 @@ export const SlippageFormStep: TransitionStep<NewPositionCardStep> = ({
 }) => {
   const { t } = useTranslation();
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
   const {
     ammState,
     traderState,
     perpetualParameters: perpParameters,
     averagePrice,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const { trade, onChangeTrade } = useContext(NewPositionCardContext);
 

--- a/src/app/pages/PerpetualPage/components/PairSelector/PairSelectorButton.tsx
+++ b/src/app/pages/PerpetualPage/components/PairSelector/PairSelectorButton.tsx
@@ -33,14 +33,12 @@ export const PairSelectorButton: React.FC<PairSelectorButtonProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const currentPairId = usePerpetual_getCurrentPairId();
   const { perpetuals } = useContext(PerpetualQueriesContext);
-  const { ammState } = perpetuals[currentPairId];
+  const { ammState } = perpetuals[pair.id];
 
   const [trend, setTrend] = useState<TradePriceChange>(
     TradePriceChange.NO_CHANGE,
   );
-
   const markPrice = getMarkPrice(ammState);
   const previousMarkPrice = usePrevious(markPrice);
 

--- a/src/app/pages/PerpetualPage/components/PairSelector/PairSelectorButton.tsx
+++ b/src/app/pages/PerpetualPage/components/PairSelector/PairSelectorButton.tsx
@@ -16,6 +16,7 @@ import { perpUtils } from '@sovryn/perpetual-swap';
 import { TradePriceChange } from '../RecentTradesTable/types';
 import { getPriceColor, getPriceChange } from '../RecentTradesTable/utils';
 import { usePrevious } from '../../../../hooks/usePrevious';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 const { getMarkPrice } = perpUtils;
 
@@ -31,7 +32,11 @@ export const PairSelectorButton: React.FC<PairSelectorButtonProps> = ({
   onSelect,
 }) => {
   const { t } = useTranslation();
-  const { ammState } = useContext(PerpetualQueriesContext);
+
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { ammState } = perpetuals[currentPairId];
+
   const [trend, setTrend] = useState<TradePriceChange>(
     TradePriceChange.NO_CHANGE,
   );

--- a/src/app/pages/PerpetualPage/components/RecentTradesTable/index.tsx
+++ b/src/app/pages/PerpetualPage/components/RecentTradesTable/index.tsx
@@ -6,6 +6,7 @@ import { PerpetualPair } from 'utils/models/perpetual-pair';
 import { RecentTradesTableRow } from './components/RecentTablesRow/index';
 import { RecentTradesContext } from '../../contexts/RecentTradesContext';
 import { PerpetualQueriesContext } from '../../contexts/PerpetualQueriesContext';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 type RecentTradesTableProps = {
   pair: PerpetualPair;
@@ -15,7 +16,11 @@ export const RecentTradesTable: React.FC<RecentTradesTableProps> = ({
   pair,
 }) => {
   const { trades } = useContext(RecentTradesContext);
-  const { lotPrecision } = useContext(PerpetualQueriesContext);
+
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { lotPrecision } = perpetuals[currentPairId];
+
   const [style, setStyle] = useState<{ width: number }>();
 
   const ref = useRef<HTMLTableElement>(null);

--- a/src/app/pages/PerpetualPage/components/TradeDetails/index.tsx
+++ b/src/app/pages/PerpetualPage/components/TradeDetails/index.tsx
@@ -10,6 +10,7 @@ import { PerpetualTrade } from '../../types';
 import { getSignedAmount } from '../../utils/contractUtils';
 import { getTraderPnLInBC } from '../../utils/perpUtils';
 import { PerpetualQueriesContext } from '../../contexts/PerpetualQueriesContext';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 type TradeDetailsProps = {
   className?: string;
@@ -26,12 +27,14 @@ export const TradeDetails: React.FC<TradeDetailsProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
   const {
     ammState,
     perpetualParameters,
     traderState,
     availableBalance,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const positionSize = useMemo(
     () => getSignedAmount(trade.position, trade.amount),

--- a/src/app/pages/PerpetualPage/components/TradeDialog/components/ReviewStep.tsx
+++ b/src/app/pages/PerpetualPage/components/TradeDialog/components/ReviewStep.tsx
@@ -18,6 +18,7 @@ import { usePerpetual_isTradingInMaintenance } from 'app/pages/PerpetualPage/hoo
 import { useMaintenance } from '../../../../../hooks/useMaintenance';
 import { useSelector } from 'react-redux';
 import { selectPerpetualPage } from '../../../selectors';
+import { usePerpetual_getCurrentPairId } from 'app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId';
 
 const titleMap = {
   [PerpetualPageModals.NONE]:
@@ -37,7 +38,11 @@ export const ReviewStep: TransitionStep<TradeDialogStep> = ({ changeTo }) => {
   const { origin, trade, pair, analysis, setCurrentTransaction } = useContext(
     TradeDialogContext,
   );
-  const { lotSize, lotPrecision } = useContext(PerpetualQueriesContext);
+
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { lotSize, lotPrecision } = perpetuals[currentPairId];
+
   const { useMetaTransactions } = useSelector(selectPerpetualPage);
 
   const { checkMaintenance, States } = useMaintenance();

--- a/src/app/pages/PerpetualPage/components/TradeDialog/index.tsx
+++ b/src/app/pages/PerpetualPage/components/TradeDialog/index.tsx
@@ -32,6 +32,7 @@ import { TransactionStep } from './components/TransactionStep';
 import { PerpetualQueriesContext } from '../../contexts/PerpetualQueriesContext';
 import { numberFromWei } from '../../../../../utils/blockchain/math-helpers';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 const {
   calculateApproxLiquidationPrice,
@@ -79,11 +80,13 @@ export const TradeDialog: React.FC = () => {
   const dispatch = useDispatch();
   const { modal, modalOptions } = useSelector(selectPerpetualPage);
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
   const {
     ammState,
     traderState,
     perpetualParameters: perpParameters,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const { origin, trade, transactions: requestedTransactions } = useMemo(
     () =>

--- a/src/app/pages/PerpetualPage/components/TradeForm/index.tsx
+++ b/src/app/pages/PerpetualPage/components/TradeForm/index.tsx
@@ -39,6 +39,7 @@ import { getCollateralName } from '../../utils/renderUtils';
 import { TxType } from '../../../../../store/global/transactions-store/types';
 import { perpMath, perpUtils } from '@sovryn/perpetual-swap';
 import { getRequiredMarginCollateralWithGasFees } from '../../utils/perpUtils';
+import { usePerpetual_getCurrentPairId } from '../../hooks/usePerpetual_getCurrentPairId';
 
 const { shrinkToLot } = perpMath;
 const {
@@ -78,6 +79,8 @@ export const TradeForm: React.FC<ITradeFormProps> = ({
 
   const { useMetaTransactions } = useSelector(selectPerpetualPage);
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
   const {
     ammState,
     traderState,
@@ -87,7 +90,7 @@ export const TradeForm: React.FC<ITradeFormProps> = ({
     lotSize,
     lotPrecision,
     availableBalance,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const pair = useMemo(() => PerpetualPairDictionary.get(pairType), [pairType]);
   const collateralName = useMemo(() => getCollateralName(collateral), [

--- a/src/app/pages/PerpetualPage/contexts/RecentTradesContext.tsx
+++ b/src/app/pages/PerpetualPage/contexts/RecentTradesContext.tsx
@@ -95,7 +95,7 @@ const formatRecentTradesData = (data: { trades: any[]; liquidates: any[] }) =>
   ]
     .sort((a, b) => b.time - a.time)
     .map((trade, index, array) => {
-      console.log(trade.time);
+      //console.log(trade.time);
       const prevTrade = index < array.length - 1 ? array[index + 1] : trade;
       return {
         ...trade,

--- a/src/app/pages/PerpetualPage/hooks/usePerpetual_AmmDepthChart.ts
+++ b/src/app/pages/PerpetualPage/hooks/usePerpetual_AmmDepthChart.ts
@@ -4,6 +4,7 @@ import { PerpetualQueriesContext } from '../contexts/PerpetualQueriesContext';
 import { RecentTradesContext } from '../contexts/RecentTradesContext';
 import { TradePriceChange } from '../components/RecentTradesTable/types';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from './usePerpetual_getCurrentPairId';
 
 const { getIndexPrice, getMarkPrice } = perpUtils;
 
@@ -26,9 +27,12 @@ export type AmmDepthChartData = {
 export const usePerpetual_AmmDepthChart = (
   pair: PerpetualPair,
 ): AmmDepthChartData => {
-  const { ammState, depthMatrixEntries: entries, averagePrice } = useContext(
-    PerpetualQueriesContext,
-  );
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { ammState, depthMatrixEntries: entries, averagePrice } = perpetuals[
+    currentPairId
+  ];
+
   const { trades } = useContext(RecentTradesContext);
 
   const data = useMemo(() => {

--- a/src/app/pages/PerpetualPage/hooks/usePerpetual_ClosedPositions.ts
+++ b/src/app/pages/PerpetualPage/hooks/usePerpetual_ClosedPositions.ts
@@ -15,6 +15,7 @@ import {
 import { RecentTradesContext } from '../contexts/RecentTradesContext';
 import debounce from 'lodash.debounce';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from './usePerpetual_getCurrentPairId';
 
 const { getQuote2CollateralFX } = perpUtils;
 
@@ -40,7 +41,10 @@ export const usePerpetual_ClosedPositions = (
 ): ClosedPositionHookResult => {
   const address = useAccount();
 
-  const { ammState } = useContext(PerpetualQueriesContext);
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { ammState } = perpetuals[currentPairId];
+
   const { latestTradeByUser } = useContext(RecentTradesContext);
 
   const pair = useMemo(() => PerpetualPairDictionary.get(pairType), [pairType]);

--- a/src/app/pages/PerpetualPage/hooks/usePerpetual_ContractDetails.ts
+++ b/src/app/pages/PerpetualPage/hooks/usePerpetual_ContractDetails.ts
@@ -9,6 +9,7 @@ import {
   PerpetualPairDictionary,
 } from '../../../../utils/dictionaries/perpetual-pair-dictionary';
 import { useApolloClient } from '@apollo/client';
+import { usePerpetual_getCurrentPairId } from './usePerpetual_getCurrentPairId';
 
 export type PerpetualContractDetailsData = {
   volume24h: number;
@@ -22,9 +23,9 @@ export const usePerpetual_ContractDetails = (pairType: PerpetualPairType) => {
   const [volume24h, setVolume24h] = useState(0);
   const [data, setData] = useState<Nullable<PerpetualContractDetailsData>>();
 
-  const { ammState, perpetualParameters, lotSize } = useContext(
-    PerpetualQueriesContext,
-  );
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { ammState, perpetualParameters, lotSize } = perpetuals[currentPairId];
   const client = useApolloClient();
 
   const pair = useMemo(() => PerpetualPairDictionary.get(pairType), [pairType]);

--- a/src/app/pages/PerpetualPage/hooks/usePerpetual_OpenPositions.ts
+++ b/src/app/pages/PerpetualPage/hooks/usePerpetual_OpenPositions.ts
@@ -17,6 +17,7 @@ import { PerpetualQueriesContext } from '../contexts/PerpetualQueriesContext';
 import { RecentTradesContext } from '../contexts/RecentTradesContext';
 import debounce from 'lodash.debounce';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from './usePerpetual_getCurrentPairId';
 
 export type OpenPositionEntry = {
   id: string;
@@ -75,11 +76,14 @@ export const usePerpetual_OpenPosition = (
 
   const { latestTradeByUser } = useContext(RecentTradesContext);
 
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+
   const {
     ammState,
     traderState,
     perpetualParameters: perpParameters,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const data = useMemo(() => {
     const base2quote = getBase2QuoteFX(ammState, true);

--- a/src/app/pages/PerpetualPage/hooks/usePerpetual_accountBalance.ts
+++ b/src/app/pages/PerpetualPage/hooks/usePerpetual_accountBalance.ts
@@ -6,6 +6,7 @@ import {
 import { bignumber } from 'mathjs';
 import { PerpetualQueriesContext } from '../contexts/PerpetualQueriesContext';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from './usePerpetual_getCurrentPairId';
 
 const { getTraderPnLInCC, getQuote2CollateralFX } = perpUtils;
 
@@ -20,12 +21,14 @@ type AccountBalance = {
 };
 
 export const usePerpetual_accountBalance = (): AccountBalance => {
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
   const {
     ammState,
     traderState,
     perpetualParameters,
     availableBalance,
-  } = useContext(PerpetualQueriesContext);
+  } = perpetuals[currentPairId];
 
   const unrealizedPnl = useMemo(
     () => getTraderPnLInCC(traderState, ammState, perpetualParameters),

--- a/src/app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId.ts
+++ b/src/app/pages/PerpetualPage/hooks/usePerpetual_getCurrentPairId.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { PerpetualPairDictionary } from 'utils/dictionaries/perpetual-pair-dictionary';
+import { selectPerpetualPage } from '../selectors';
+
+export const usePerpetual_getCurrentPairId = () => {
+  const { pairType } = useSelector(selectPerpetualPage);
+
+  const pair = useMemo(() => PerpetualPairDictionary.get(pairType), [pairType]);
+
+  return pair.id || PerpetualPairDictionary.list()[0].id;
+};

--- a/src/app/pages/PerpetualPage/hooks/usePerpetual_openTrade.ts
+++ b/src/app/pages/PerpetualPage/hooks/usePerpetual_openTrade.ts
@@ -19,6 +19,7 @@ import { Asset } from '../../../../types';
 import { PerpetualTx } from '../components/TradeDialog/types';
 import { useGsnSendTx } from '../../../hooks/useGsnSendTx';
 import { perpUtils } from '@sovryn/perpetual-swap';
+import { usePerpetual_getCurrentPairId } from './usePerpetual_getCurrentPairId';
 
 const { calculateSlippagePrice } = perpUtils;
 
@@ -34,7 +35,9 @@ export const usePerpetual_openTrade = (
     pairType,
   ]);
 
-  const { averagePrice } = useContext(PerpetualQueriesContext);
+  const currentPairId = usePerpetual_getCurrentPairId();
+  const { perpetuals } = useContext(PerpetualQueriesContext);
+  const { averagePrice } = perpetuals[currentPairId];
 
   const { send, ...rest } = useGsnSendTx(
     PERPETUAL_CHAIN,


### PR DESCRIPTION
Partially resolves https://sovryn.monday.com/boards/2218344956/pulses/2508572752 .

This PR changes the way we fetch data (ammState, traderState, ...) in perpetuals. Historically, we fetched them for the current pair only but we need to fetch them for all the pairs at once so we can display all of the Open positions, different Mark prices etc.