### PR TITLE
feat: enforce new checkboxs

### DIFF
--- a/src/app/components/Checkbox/index.module.scss
+++ b/src/app/components/Checkbox/index.module.scss
@@ -6,7 +6,7 @@
 }
 
 .checkbox {
-  @apply tw-bg-sov-white tw-mr-2.5 tw-inline-block tw-h-4 tw-w-4 tw-rounded;
+  @apply tw-bg-sov-white tw-mr-2.5 tw-inline-block tw-h-4 tw-w-4 tw-rounded tw-flex-shrink-0;
 }
 
 .checkboxChecked {

--- a/src/app/components/FirstVisitDisclaimerDialog/index.tsx
+++ b/src/app/components/FirstVisitDisclaimerDialog/index.tsx
@@ -1,13 +1,11 @@
-import { Checkbox } from '@blueprintjs/core';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-
 import { isMobile } from 'utils/helpers';
-
 import { translations } from '../../../locales/i18n';
 import { local } from '../../../utils/storage';
 import { Dialog } from '../../containers/Dialog/Loadable';
 import SalesButton from '../SalesButton';
+import { Checkbox } from '../Checkbox';
 import logo from 'assets/images/sovryn-logo-white.svg';
 
 // previously MetaMask disclaimer, 'mm-…' remains to not annoy users.

--- a/src/app/components/MobileBrowsersWarningDialog/index.tsx
+++ b/src/app/components/MobileBrowsersWarningDialog/index.tsx
@@ -3,11 +3,11 @@ import { Dialog } from '../../containers/Dialog/Loadable';
 import logo from 'assets/images/sovryn-logo-horz-white.png';
 import { isMobile } from 'utils/helpers';
 import { noop } from '../../constants';
-import { Checkbox } from '@blueprintjs/core';
 import SalesButton from '../SalesButton';
 import { WarningContainer, WarningTextContent } from './styled';
 import { useTranslation } from 'react-i18next';
 import { translations } from '../../../locales/i18n';
+import { Checkbox } from '../Checkbox';
 
 export const MobileBrowsersWarningDialog: React.FC = () => {
   const { t } = useTranslation();

--- a/src/app/components/OptOutDialog/index.tsx
+++ b/src/app/components/OptOutDialog/index.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Dialog } from '../../containers/Dialog';
 import { FormGroup } from 'app/components/Form/FormGroup';
-import { Checkbox } from '@blueprintjs/core';
 import { DialogButton } from 'app/components/Form/DialogButton';
 import { translations } from '../../../locales/i18n';
 import { useTranslation } from 'react-i18next';
 import { useCookie } from 'app/hooks/useCookie';
 import { sovAnalyticsCookie } from 'utils/classifiers';
+import { Checkbox } from '../Checkbox';
 
 export interface OptOutProps {
   open: boolean;
@@ -33,6 +33,8 @@ export default function OptOutDialog(props: OptOutProps) {
       setOptIn(!(get(sovAnalyticsCookie.name) === sovAnalyticsCookie.value));
   }, [props.open, get]);
 
+  const handleChange = useCallback(() => setOptIn(!!!optIn), [optIn]);
+
   return (
     <>
       <Dialog isOpen={props.open} onClose={props.onClose}>
@@ -46,13 +48,11 @@ export default function OptOutDialog(props: OptOutProps) {
             </div>
             <FormGroup className="tw-mb-6">
               <Checkbox
-                name="analytics"
+                label={t(translations.analyticsDialog.option)}
                 checked={optIn}
-                onChange={e => setOptIn(!!!optIn)}
+                onChange={handleChange}
                 className="tw-text-sm md:tw-col-span-8 sm:tw-col-span-12"
-              >
-                {t(translations.analyticsDialog.option)}
-              </Checkbox>
+              />
             </FormGroup>
             <div className="tw-mb-6">
               {t(translations.analyticsDialog.message_2)}

--- a/src/app/pages/MarginTradePage/components/TradeDialog/TradeDialogContent.tsx
+++ b/src/app/pages/MarginTradePage/components/TradeDialog/TradeDialogContent.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { HashZero } from '@ethersproject/constants';
-import { Checkbox } from '@blueprintjs/core';
 import { DialogButton } from 'app/components/Form/DialogButton';
 import { ErrorBadge } from 'app/components/Form/ErrorBadge';
 import { useSlippage } from 'app/pages/BuySovPage/components/BuyForm/useSlippage';
@@ -53,6 +52,7 @@ import { usePositionLiquidationPrice } from 'app/hooks/trading/usePositionLiquid
 import { LoadableValue } from 'app/components/LoadableValue';
 import { PricePrediction } from 'app/containers/MarginTradeForm/PricePrediction';
 import { MarginDetails } from 'app/hooks/trading/useGetEstimatedMarginDetails';
+import { Checkbox } from 'app/components/Checkbox';
 
 interface ITradeDialogContentProps {
   slippage: number;
@@ -258,6 +258,10 @@ export const TradeDialogContent: React.FC<ITradeDialogContentProps> = ({
     return ignoreError ? false : simulator.status === SimulationStatus.FAILED;
   }, [ignoreError, simulator.status]);
 
+  const handleIgnoreError = useCallback(() => setIgnoreError(!ignoreError), [
+    ignoreError,
+  ]);
+
   return (
     <div className="tw-w-auto md:tw-mx-7 tw-mx-2">
       <h1 className="tw-text-sov-white tw-text-center">
@@ -405,7 +409,7 @@ export const TradeDialogContent: React.FC<ITradeDialogContentProps> = ({
             />
             <Checkbox
               checked={ignoreError}
-              onChange={() => setIgnoreError(!ignoreError)}
+              onChange={handleIgnoreError}
               label={t(translations.common.continueToFailure)}
               data-action-id="accept-terms-checkbox"
             />

--- a/src/app/pages/OriginsLaunchpad/pages/SalesDay/pages/ImportantInformationStep/index.tsx
+++ b/src/app/pages/OriginsLaunchpad/pages/SalesDay/pages/ImportantInformationStep/index.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { Checkbox } from '@blueprintjs/core';
 import { Link } from 'react-router-dom';
 
 import { translations } from 'locales/i18n';
 import { ActionButton } from 'app/components/Form/ActionButton';
 import { discordInvite, sovrynTelegram } from 'utils/classifiers';
 import styles from './index.module.scss';
+import { Checkbox } from 'app/components/Checkbox';
 
 interface IImportantInformationStepProps {
   saleName: string;

--- a/src/styles/sass/blueprint-override.scss
+++ b/src/styles/sass/blueprint-override.scss
@@ -123,11 +123,3 @@ article.bp3-dialog h1 {
     }
   }
 }
-
-.bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator:before {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E");
-}
-
-.bp3-control.bp3-checkbox input:indeterminate ~ .bp3-control-indicator:before {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M11 7H5c-.55 0-1 .45-1 1s.45 1 1 1h6c.55 0 1-.45 1-1s-.45-1-1-1z' fill='%23fff'/%3E%3C/svg%3E");
-}


### PR DESCRIPTION
https://sovryn.monday.com/boards/2218344956/pulses/2426081428

Checkbox'es changed at:
- First visit / welcome dialog (use incognito to open)
- Mobile browser warning dialog (use mobile device)
- Tracking opt out dialog (click "Opt-out from Google Analytics" in the footer)
- Margin Trade dialog - failed tx simulation error bypass (only visible when simulator expects transaction to fail)
- Origins Sale -> Terms & Conditions to accept before sale (only visible when sale is active)

Old checkboxes has check mark symbol which is white, new ones - black.
