### PR TITLE
fix: margin trading issues

### DIFF
--- a/src/app/pages/BuySovPage/components/BuyForm/useSlippage.ts
+++ b/src/app/pages/BuySovPage/components/BuyForm/useSlippage.ts
@@ -8,6 +8,6 @@ export function useSlippage(amount: string, slippage: number = 0.1) {
   return {
     amount,
     slippage,
-    minReturn: minReturn === 'NaN' ? '0' : minReturn,
+    minReturn: minReturn === 'NaN' ? '1' : minReturn,
   };
 }

--- a/src/app/pages/MarginTradePage/components/TradeDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/TradeDialog/index.tsx
@@ -31,6 +31,7 @@ import {
 } from './trading-dialog.helpers';
 import { MarginDetails } from 'app/hooks/trading/useGetEstimatedMarginDetails';
 import { TradeDialogContent } from './TradeDialogContent';
+import { useLog } from 'app/hooks/useDebug';
 
 interface ITradeDialogProps {
   slippage: number;
@@ -97,6 +98,13 @@ export const TradeDialog: React.FC<ITradeDialogProps> = ({
   }, [borrowAmount, collateralTokensReceived]);
 
   const { minReturn } = useSlippage(collateralTokenAmount, slippage);
+
+  useLog('min return', {
+    collateralTokensReceived,
+    borrowAmount,
+    collateralTokenAmount,
+    minReturn,
+  });
 
   const { trade, ...tx } = useApproveAndTrade(
     pair,

--- a/src/app/pages/MarginTradePage/components/TradeForm/index.tsx
+++ b/src/app/pages/MarginTradePage/components/TradeForm/index.tsx
@@ -9,11 +9,7 @@ import { ErrorBadge } from 'app/components/Form/ErrorBadge';
 import { FormGroup } from 'app/components/Form/FormGroup';
 import { useMaintenance } from 'app/hooks/useMaintenance';
 import settingIcon from 'assets/images/settings-blue.svg';
-import {
-  discordInvite,
-  useTenderlySimulator,
-  WIKI_LIMIT_ORDER_LIMITS_LINK,
-} from 'utils/classifiers';
+import { discordInvite, WIKI_LIMIT_ORDER_LIMITS_LINK } from 'utils/classifiers';
 import { translations } from 'locales/i18n';
 import { TradingPosition } from 'types/trading-position';
 import styles from './index.module.scss';
@@ -34,20 +30,13 @@ import { CollateralAssets } from '../CollateralAssets';
 import { LeverageSelector } from '../LeverageSelector';
 import { useGetEstimatedMarginDetails } from 'app/hooks/trading/useGetEstimatedMarginDetails';
 import { TradeDialog } from '../TradeDialog';
-import { LiquidationPrice } from '../LiquidationPrice';
 import { useCurrentPositionPrice } from 'app/hooks/trading/useCurrentPositionPrice';
-import {
-  toAssetNumberFormat,
-  toNumberFormat,
-  weiToNumberFormat,
-} from 'utils/display-text/format';
+import { weiToNumberFormat } from 'utils/display-text/format';
 import { SlippageForm } from '../SlippageForm';
 import { fromWei, toWei } from 'utils/blockchain/math-helpers';
 import { OrderType } from 'app/components/OrderTypeTitle/types';
 import { MARGIN_SLIPPAGE_DEFAULT } from '../../types';
 import { AssetRenderer } from 'app/components/AssetRenderer';
-import { LoadableValue } from 'app/components/LoadableValue';
-import { PricePrediction } from 'app/containers/MarginTradeForm/PricePrediction';
 import { durationOptions } from 'app/pages/SpotTradingPage/components/LimitOrderSetting/Duration';
 import { OrderTypeTitle } from 'app/components/OrderTypeTitle';
 import { LimitTradeDialog } from '../LimitOrder/LimitTradeDialog';
@@ -394,55 +383,6 @@ export const TradeForm: React.FC<ITradeFormProps> = ({ pairType }) => {
 
           {!openTradesLocked && (
             <>
-              {orderType !== OrderType.LIMIT && (
-                <LabelValuePair
-                  label={t(translations.marginTradeForm.fields.esEntryPrice)}
-                  value={
-                    <>
-                      {useTenderlySimulator ? (
-                        <>
-                          <LoadableValue
-                            loading={loadingPrice}
-                            value={toAssetNumberFormat(price, pair.longAsset)}
-                            tooltip={toNumberFormat(price, 18)}
-                          />{' '}
-                          <AssetRenderer asset={pair.longAsset} />
-                        </>
-                      ) : (
-                        <>
-                          <PricePrediction
-                            position={position}
-                            leverage={leverage}
-                            loanToken={loanToken}
-                            collateralToken={collateralToken}
-                            useLoanTokens={useLoanTokens}
-                            weiAmount={amount}
-                            asset={pair.longAsset}
-                          />{' '}
-                          <AssetRenderer asset={pair.longAsset} />
-                        </>
-                      )}
-                    </>
-                  }
-                />
-              )}
-
-              <LabelValuePair
-                label={t(
-                  translations.marginTradeForm.fields.esLiquidationPrice,
-                )}
-                value={
-                  <>
-                    <LiquidationPrice
-                      asset={pair.shortAsset}
-                      assetLong={pair.longAsset}
-                      leverage={leverage}
-                      position={position}
-                    />{' '}
-                    <AssetRenderer asset={pair.longAsset} />
-                  </>
-                }
-              />
               <LabelValuePair
                 label={t(translations.marginTradeForm.fields.interestAPR)}
                 value={<>{weiToNumberFormat(estimations.interestRate, 2)} %</>}


### PR DESCRIPTION
temporary quick fixes:

- fixes estimated liquidation price in dialog
- hides incorrect estimated entry price in margin form
- hides incorrect estimated liquidation price in margin form
- enforces `minReturn` (slippage) to 1 for SOV/RBTC pair