### PR TITLE
chore(deps): bump sovryn wallet version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@reduxjs/toolkit": "1.5.1",
     "@rsksmart/rsk3": "0.3.4",
     "@sovryn/charting-library": "1.0.0",
-    "@sovryn/react-wallet": "2.2.2",
+    "@sovryn/react-wallet": "2.2.3",
     "@sovryn/perpetual-swap": "3.0.0",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4736,14 +4736,14 @@
     node-fetch "^2.6.6"
     web3 "^1.6.0"
 
-"@sovryn/react-wallet@2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.2.2.tgz#0049f746f5ee62d7dd37972b5a39b7a9d184e21c"
-  integrity sha512-zPWFd39HsjDRBVpdgHLv/aIJv3lP+AYWPP1y19zxBm1WxeTCCnlZ0nZgR0+VWYlbr1n0j0dOrg7VwmZodQfaqw==
+"@sovryn/react-wallet@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@sovryn/react-wallet/-/react-wallet-2.2.3.tgz#1e44b7240258c63a98f82a2fd1ddca371be734e6"
+  integrity sha512-u6Ua8CXBB3XnoOG/bbxbcVHGVbX+pwApZgelwz9RCfJ77V0IB64wz7pfQq2PyP9p0cEmPIBI2gfMTZMt+mzEfQ==
   dependencies:
     "@blueprintjs/core" "^3.44.2"
     "@hookstate/core" "^3.0.6"
-    "@sovryn/wallet" "^2.2.1"
+    "@sovryn/wallet" "^2.2.3"
     "@types/classnames" "^2.2.11"
     "@types/react-copy-to-clipboard" "^5.0.0"
     caniuse-lite "^1.0.30001287"
@@ -4760,10 +4760,10 @@
     web3 "^1.3.6"
     web3-core "^1.3.6"
 
-"@sovryn/wallet@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.2.1.tgz#c6bc2eeffcd70e7f4b26a7a4c66fd65664b48b64"
-  integrity sha512-tYA6PnQg0kMLDDN0KuOTeK4mJeBoCJjy2sK8zU//vkhMUs5R2lrqf2855kRGvtx/Z/lBwYKmdJLrJG78q5wj0g==
+"@sovryn/wallet@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@sovryn/wallet/-/wallet-2.2.3.tgz#b54d6a1bebb9f790eea6abcdbc77c35d5306476a"
+  integrity sha512-PVoDilnItof3/i+7ztaK61to+CekqQ46GRypEh420bTeJxlAHy7D308mu8ksoZjwE5r9iU50x6W9dfDQGMm5DQ==
   dependencies:
     "@ledgerhq/hw-app-eth" "^5.53.0"
     "@ledgerhq/hw-transport" "^5.51.1"


### PR DESCRIPTION
Added newest sovryn wallet library which introduces deprecation message for nifty wallet.

AC:
- When connecting to the dapp, Nifty Wallet has deprecation message with hyperlink linking to the wiki