### PR TITLE
Fix/recent trades loading fix

### DIFF
--- a/src/app/components/RecentTrades/MarginTrades.tsx
+++ b/src/app/components/RecentTrades/MarginTrades.tsx
@@ -74,7 +74,7 @@ export const MarginTrades: React.FC<IMarginTradesProps> = ({
           <>
             {Array(15)
               .fill(1)
-              .map(index => (
+              .map((item, index) => (
                 <tr className="tw-h-6" key={index}>
                   <td colSpan={4}>
                     <p className="tw-skeleton-wrapper bp3-skeleton tw-m-0 tw-p-3"></p>

--- a/src/app/components/RecentTrades/SwapTrades.tsx
+++ b/src/app/components/RecentTrades/SwapTrades.tsx
@@ -125,7 +125,7 @@ export const SwapTrades: React.FC<ISwapTradesProps> = ({
           <>
             {Array(10)
               .fill(1)
-              .map(index => (
+              .map((item, index) => (
                 <tr className="tw-h-6" key={index}>
                   <td colSpan={4}>
                     <p className="tw-skeleton-wrapper bp3-skeleton tw-m-0 tw-p-3"></p>

--- a/src/app/components/RecentTrades/index.tsx
+++ b/src/app/components/RecentTrades/index.tsx
@@ -18,7 +18,7 @@ export const RecentTrades: React.FC<IRecentTradesProps> = ({
   quoteToken,
 }) => {
   const { t } = useTranslation();
-  const data = useMargin_RecentTrades(baseToken, quoteToken);
+  const { data, loading } = useMargin_RecentTrades(baseToken, quoteToken);
 
   return (
     <div
@@ -54,7 +54,8 @@ export const RecentTrades: React.FC<IRecentTradesProps> = ({
           </tr>
         </thead>
         <tbody>
-          {data &&
+          {!loading &&
+            data &&
             data.map((item, index) => {
               return (
                 <RecentTradeRow
@@ -67,16 +68,25 @@ export const RecentTrades: React.FC<IRecentTradesProps> = ({
               );
             })}
 
-          {!data ||
-            (data.length === 0 && (
-              <tr>
-                <td colSpan={4}>
-                  <p className="tw-p-4">
-                    {t(translations.marginTradePage.recentTrades.noTrades)}
-                  </p>
-                </td>
-              </tr>
-            ))}
+          {!loading && data && data.length === 0 && (
+            <tr>
+              <td colSpan={4}>
+                <p className="tw-p-4">
+                  {t(translations.marginTradePage.recentTrades.noTrades)}
+                </p>
+              </td>
+            </tr>
+          )}
+
+          {loading && (
+            <tr>
+              <td colSpan={4}>
+                <p className="tw-p-4">
+                  {t(translations.marginTradePage.recentTrades.loading)}
+                </p>
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/src/app/hooks/trading/useMargin_RecentTrades.ts
+++ b/src/app/hooks/trading/useMargin_RecentTrades.ts
@@ -13,8 +13,10 @@ export const useMargin_RecentTrades = (baseToken: Asset, quoteToken: Asset) => {
   );
   const baseTokenAddress = getTokenContract(baseToken).address;
   const quoteTokenAddress = getTokenContract(quoteToken).address;
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    setLoading(true);
     axios
       .get(url, {
         params: {
@@ -28,8 +30,9 @@ export const useMargin_RecentTrades = (baseToken: Asset, quoteToken: Asset) => {
       })
       .catch(e => {
         console.log(e);
-      });
+      })
+      .finally(() => setLoading(false));
   }, [baseTokenAddress, quoteTokenAddress]);
 
-  return data;
+  return { data, loading };
 };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1640,7 +1640,8 @@
       "time": "Time",
       "noTrades": "No Recent Trades",
       "long": "L",
-      "short": "S"
+      "short": "S",
+      "loading": "Loading..."
     },
     "tradeDialog": {
       "title": "Review Transaction",


### PR DESCRIPTION
*add loading skeleton rows into the recent trades block

ACs:

- Skeleton rows appear in Recent Trades when data is loading
- Recent Trades and PairNavbar (price info bar at top of page) data should load independently from the chart data - this can be tested most easily by throttling network connection in browser dev tools