### PR TITLE
feat: missing data-action-ids for Spot/Swap/Margin page dialog buttons

### DIFF
--- a/src/app/containers/SwapFormContainer/components/ReviewDialog/index.tsx
+++ b/src/app/containers/SwapFormContainer/components/ReviewDialog/index.tsx
@@ -118,6 +118,7 @@ export const ReviewDialog: React.FC<IReviewDialogProps> = ({
             confirmLabel={t(translations.common.confirm)}
             onConfirm={submit}
             disabled={swapDialogLocked}
+            data-action-id="swap-reviewDialog-confirm"
           />
         </div>
       </Dialog>

--- a/src/app/pages/MarginTradePage/components/TradeDialog/TradeDialogContent.tsx
+++ b/src/app/pages/MarginTradePage/components/TradeDialog/TradeDialogContent.tsx
@@ -439,7 +439,9 @@ export const TradeDialogContent: React.FC<ITradeDialogContentProps> = ({
           confirmLabel={t(translations.common.confirm)}
           onConfirm={onSubmit}
           disabled={openTradesLocked || disableButtonAfterSimulatorError}
-          data-action-id="margin-reviewTransaction-button-confirm"
+          data-action-id={`margin-reviewTransaction-${
+            position === TradingPosition.LONG ? 'long' : 'short'
+          }-confirm`}
         />
       </div>
     </div>

--- a/src/app/pages/SpotTradingPage/components/TradeDialog/index.tsx
+++ b/src/app/pages/SpotTradingPage/components/TradeDialog/index.tsx
@@ -191,7 +191,9 @@ export const TradeDialog: React.FC<ITradeDialogProps> = ({
             confirmLabel={t(translations.common.confirm)}
             onConfirm={submit}
             disabled={spotLocked || !connected || buttonLoading}
-            data-action-id="spot-reviewDialog-submit"
+            data-action-id={`spot-reviewDialog-${
+              tradeType === TradingTypes.BUY ? 'buy' : 'sell'
+            }-submit`}
           />
         </div>
       </Dialog>


### PR DESCRIPTION
https://sovryn.monday.com/boards/2218344956/pulses/2823608139

Adds missing data-action-id's on Spot/Swap/Margin page dialog buttons.