### PR TITLE
feat: add extra rel attribute to favicon for metamask "connected sites"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
       href="%PUBLIC_URL%/safari-pinned-tab.svg"
       color="#ffffff"
     />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" id="favicon" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" id="favicon" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Crypto Margin Trading with Sovryn" />


### PR DESCRIPTION
https://sovryn.monday.com/boards/2218344956/pulses/2775984700

Adds support for Sovryn favicon to appear in list of Connected Sites in Metamask