### PR TITLE
Added isLimit where clause to swap history

### DIFF
--- a/src/utils/graphql/rsk/generated.tsx
+++ b/src/utils/graphql/rsk/generated.tsx
@@ -12465,7 +12465,11 @@ export type GetStakeHistoryQueryResult = Apollo.QueryResult<
 >;
 export const GetSwapHistoryDocument = gql`
   query getSwapHistory($user: String) {
-    swaps(where: { user: $user }, orderBy: timestamp, orderDirection: desc) {
+    swaps(
+      where: { user: $user, isLimit: false }
+      orderBy: timestamp
+      orderDirection: desc
+    ) {
       fromToken {
         id
       }

--- a/src/utils/graphql/rsk/operations/getSwapHistory.graphql
+++ b/src/utils/graphql/rsk/operations/getSwapHistory.graphql
@@ -1,5 +1,9 @@
 query getSwapHistory($user: String) {
-  swaps(where: { user: $user, isLimit: false }, orderBy: timestamp, orderDirection: desc) {
+  swaps(
+    where: { user: $user, isLimit: false }
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
     fromToken {
       id
     }

--- a/src/utils/graphql/rsk/operations/getSwapHistory.graphql
+++ b/src/utils/graphql/rsk/operations/getSwapHistory.graphql
@@ -1,5 +1,5 @@
 query getSwapHistory($user: String) {
-  swaps(where: { user: $user }, orderBy: timestamp, orderDirection: desc) {
+  swaps(where: { user: $user, isLimit: false }, orderBy: timestamp, orderDirection: desc) {
     fromToken {
       id
     }


### PR DESCRIPTION
Changes to the subgraph mean that limit orders were showing up in User Swap/Spot history.

This PR adds a where clause isLimit: false to the graphql query to fix this

Jira ticket: https://sovryn.atlassian.net/browse/SOV-716
