### PR TITLE
Fix ErrorBadge fail in MarginTrade

### DIFF
--- a/src/app/pages/MarginTradePage/components/ClosePositionDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/ClosePositionDialog/index.tsx
@@ -296,7 +296,9 @@ export const ClosePositionDialog: React.FC<IClosePositionDialogProps> = ({
             />
           )}
 
-          {weiAmount !== '0' && error && <ErrorBadge content={error} />}
+          {weiAmount !== '0' && error && (
+            <ErrorBadge content={error.toString()} />
+          )}
 
           {closeTradesLocked && (
             <ErrorBadge


### PR DESCRIPTION
Fixes an issue found by Julio on Margin trade page - the page was crashing because returned error was an object instead of a string.