### PR TITLE
chore: fix analytics visit tracking with no GA id

### DIFF
--- a/src/app/containers/WalletProvider/saga.ts
+++ b/src/app/containers/WalletProvider/saga.ts
@@ -239,19 +239,24 @@ function* testTransactionsPeriodically() {
 
 function* addVisitSaga({ payload }: PayloadAction<string>) {
   try {
-    yield call([axios, axios.post], backendUrl[currentChainId] + '/addVisit', {
+    let finalPayload: { walletAddress: string; cid?: string } = {
       walletAddress: payload,
-    });
+    };
+    yield call(
+      [axios, axios.post],
+      backendUrl[currentChainId] + '/addVisit',
+      finalPayload,
+    );
     const ga = yield window.cookieStore.get('_ga');
-    const cid = ga !== null ? ga.value.slice(6, ga.value.length) : null;
+    if (ga !== null) {
+      finalPayload.cid = ga.value.slice(6, ga.value.length);
+    }
+
     const queryString = new URL(window.location.href).search;
     yield call(
       [axios, axios.post],
       userLogUrl[currentChainId] + '/visit' + queryString,
-      {
-        walletAddress: payload,
-        cid: cid,
-      },
+      finalPayload,
     );
   } catch (error) {
     log.error('failed to log visit', error);


### PR DESCRIPTION
Resolves issue where analytics tracking endpoint throws error when you don't send cid (GA id) - e.g. if you use browser that blocks it, or don't have tracking cookie enabled. This PR changes query so it only adds that prop to payload if it exists