### PR TITLE
SOV-970: Fix for failing auth

### DIFF
--- a/src/app/components/NetworkRibbon/NetworkRibbon.tsx
+++ b/src/app/components/NetworkRibbon/NetworkRibbon.tsx
@@ -12,10 +12,6 @@ import { DetectionScreen } from './component/DetectionScreen';
 import { TutorialScreen } from './component/TutorialScreen';
 import { selectWalletProvider } from '../../containers/WalletProvider/selectors';
 import { getNetworkByChainId } from '../../../utils/blockchain/networks';
-import { isMainnet } from 'utils/classifiers';
-import { ChainId } from 'types';
-
-const showPerps = !isMainnet;
 
 export function NetworkRibbon(this: any) {
   const { bridgeChainId } = useSelector(selectWalletProvider);
@@ -30,8 +26,7 @@ export function NetworkRibbon(this: any) {
     if (
       !connected ||
       !isWeb3Wallet(wallet.providerType!) ||
-      location.pathname.startsWith('/cross-chain') ||
-      (!showPerps && location.pathname.startsWith('/perpetuals'))
+      location.pathname.startsWith('/cross-chain')
     ) {
       return false;
     }
@@ -40,7 +35,7 @@ export function NetworkRibbon(this: any) {
       return chainId !== bridgeChainId;
     }
 
-    return chainId !== getExpectedChainId(expectedChainId, location.pathname);
+    return chainId !== expectedChainId;
   }, [
     bridgeChainId,
     location.pathname,
@@ -90,14 +85,3 @@ export function NetworkRibbon(this: any) {
     </NetworkDialog>
   );
 }
-
-const getExpectedChainId = (
-  expectedChainId: number | undefined,
-  pathname: string,
-) => {
-  if (pathname.startsWith('/perpetuals') && showPerps) {
-    return isMainnet ? ChainId.BSC_MAINNET : ChainId.BSC_TESTNET;
-  }
-
-  return expectedChainId;
-};

--- a/src/app/containers/PageContainer/PageContainer.tsx
+++ b/src/app/containers/PageContainer/PageContainer.tsx
@@ -13,13 +13,10 @@ import {
 } from './types';
 import { DefaultHeaderComponent } from './components/DefaultHeaderComponent/DefaultHeaderComponent';
 import { Footer } from './components/DefaultFooterComponent/DefaultFooterComponent';
-import { isMainnet } from 'utils/classifiers';
 
 type HeaderContainerProps = {
   pageOptions: PageOptions;
 };
-
-const showPerps = !isMainnet;
 
 export const PageContainer: React.FC<Partial<HeaderContainerProps>> = ({
   children,
@@ -47,11 +44,6 @@ export const PageContainer: React.FC<Partial<HeaderContainerProps>> = ({
       } else if (pathname.startsWith('/cross-chain')) {
         initialOptions.header = HeaderTypes.CROSS_CHAIN;
         initialOptions.footer = FooterTypes.NONE;
-      } else if (pathname.startsWith('/perpetuals')) {
-        initialOptions.header = HeaderTypes.LABS;
-        initialOptions.footer = showPerps
-          ? FooterTypes.PERPETUALS
-          : FooterTypes.NONE;
       } else {
         initialOptions.header = HeaderTypes.DEFAULT;
         initialOptions.footer = FooterTypes.DEFAULT;
@@ -86,8 +78,6 @@ export const PageContainer: React.FC<Partial<HeaderContainerProps>> = ({
     switch (options.footer) {
       case FooterTypes.DEFAULT:
         return <Footer {...options.footerProps} />;
-      case FooterTypes.PERPETUALS:
-        return <Footer isPerpetuals />;
       default:
         return null;
     }

--- a/src/app/containers/PageContainer/components/DefaultHeaderComponent/DefaultHeaderComponent.tsx
+++ b/src/app/containers/PageContainer/components/DefaultHeaderComponent/DefaultHeaderComponent.tsx
@@ -50,9 +50,6 @@ type PagesProps = {
   hrefExternal?: boolean;
 };
 
-// TODO: Delete this once we go live, we may need it after the competition
-const showPerps = true; // !isMainnet || isStaging;
-
 const showZero = isMainnet || isStaging;
 
 export const DefaultHeaderComponent: React.FC = () => {
@@ -129,13 +126,6 @@ export const DefaultHeaderComponent: React.FC = () => {
       title: t(translations.mainMenu.zero),
       dataActionId: 'header-mobile-lab-link-zero',
       hrefExternal: true,
-    });
-  }
-  if (showPerps) {
-    labPages.push({
-      to: '/perpetuals',
-      title: t(translations.mainMenu.perpetuals),
-      dataActionId: 'header-mobile-lab-link-perpetuals',
     });
   }
 
@@ -293,7 +283,6 @@ export const DefaultHeaderComponent: React.FC = () => {
         '/labs',
         '/zero',
         '/mynt-token',
-        '/perpetuals',
       ],
       [SECTION_TYPE.BORROW]: ['/borrow'],
     };
@@ -466,13 +455,6 @@ export const DefaultHeaderComponent: React.FC = () => {
                         dataActionId="header-lab-link-zero"
                       />
                     )}
-                    <MenuItem
-                      text={t(translations.mainMenu.perpetuals)}
-                      label={t(translations.mainMenu.labels.perpetuals)}
-                      href="/perpetuals"
-                      disabled={!showPerps}
-                      dataActionId="header-lab-link-perpetuals"
-                    />
                   </>
                 }
               >

--- a/src/app/containers/PageContainer/types.ts
+++ b/src/app/containers/PageContainer/types.ts
@@ -6,13 +6,11 @@ export enum HeaderTypes {
   FAST_BTC,
   CROSS_CHAIN,
   LABS,
-  PERPETUALS,
 }
 
 export enum FooterTypes {
   NONE,
   DEFAULT,
-  PERPETUALS,
 }
 
 export type PageContextState = {

--- a/src/app/containers/SwapFormContainer/components/SwapSelector/index.tsx
+++ b/src/app/containers/SwapFormContainer/components/SwapSelector/index.tsx
@@ -144,13 +144,13 @@ export const SwapSelector: React.FC<ISwapSelectorProps> = ({
                       return null;
                     }
 
-                    //as we don't have RBTC as source, we make a separate reverted pair from USDT_RBTC
+                    //as we don't have RBTC as source, we make a separate reverted pair from XUSD_RBTC
                     let pairDivRBTC;
                     let pairDiv;
 
                     //show RBTC asset and make it searchable
                     if (
-                      assetDetails.asset === Asset.USDT &&
+                      assetDetails.asset === Asset.XUSD &&
                       Asset.RBTC.includes(search.toUpperCase())
                     )
                       pairDivRBTC = (

--- a/src/app/hooks/trading/usePairList.ts
+++ b/src/app/hooks/trading/usePairList.ts
@@ -1,13 +1,25 @@
 import { IPairData } from 'types/trading-pairs';
+import { isMainnet, isStaging } from 'utils/classifiers';
+
+// XUSD_legacy, cannot use getContract because we don't have a mainnet contract for it
+const deprecatedPair = '0x74858FE37d391f81F89472e1D8BC8Ef9CF67B3b1'.toLowerCase();
 
 export const usePairList = (pairs: IPairData[]) => {
   if (!pairs) {
     return [];
   }
 
-  return Object.keys(pairs)
+  const pairList = Object.keys(pairs)
     .map(key => pairs[key])
     .filter((pair: IPairData) => {
       return pair;
     });
+
+  return isMainnet || isStaging
+    ? pairList
+    : pairList.filter(
+        pair =>
+          pair.base_id.toLowerCase() !== deprecatedPair &&
+          pair.quote_id.toLowerCase() !== deprecatedPair,
+      );
 };

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -49,16 +49,10 @@ import { BridgeWithdrawPage } from './pages/BridgeWithdrawPage/Loadable';
 import { FastBtcPage } from './pages/FastBtcPage/Loadable';
 import { PageContainer } from './containers/PageContainer';
 import 'react-toastify/dist/ReactToastify.css';
-import { PerpetualPageLoadable } from './pages/PerpetualPage/Loadable';
-import { PerpetualsPlaceholderPageLoadable } from './pages/PerpetualsPlaceholderPage/Loadable';
 import { ReceiveRBTCPage } from './pages/ReceiveRBTCPage';
-import { CompetitionPage } from './pages/PerpetualPage/components/CompetitionPage';
 import { usePriceFeeds_tradingPairRates } from './hooks/price-feeds/usePriceFeeds_tradingPairRates';
 
 const title = !isMainnet ? `Sovryn ${currentNetwork}` : 'Sovryn';
-
-// TODO: Delete this once we go live, we may need it after the competition
-const showPerps = !isMainnet; // !isMainnet || isStaging;
 
 export function App() {
   useAppTheme();
@@ -98,6 +92,7 @@ export function App() {
                 <Route exact path="/borrow" component={BorrowPage} />
                 <Route exact path="/stake" component={StakePage} />
                 <Redirect exact from="/liquidity" to="/yield-farm" />
+                <Redirect exact from="/perpetuals" to="/" />
                 <Route
                   exact
                   path="/yield-farm"
@@ -138,23 +133,6 @@ export function App() {
                   component={FastBtcPage}
                 />
                 <Route exact path="/rbtc/" component={ReceiveRBTCPage} />
-
-                <Route
-                  exact
-                  path="/perpetuals"
-                  component={
-                    showPerps
-                      ? PerpetualPageLoadable
-                      : PerpetualsPlaceholderPageLoadable
-                  }
-                />
-                {showPerps && (
-                  <Route
-                    exact
-                    path="/perpetuals/competition"
-                    component={CompetitionPage}
-                  />
-                )}
                 <Route component={NotFoundPage} />
               </Switch>
             </PageContainer>

--- a/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
@@ -80,28 +80,33 @@ export const NotificationSettingsDialog: React.FC<INotificationSettingsDialogPro
     if (!account) return;
     const timestamp = new Date();
     const message = `Login to backend on: ${timestamp}`;
-    return axios
-      .get(url + 'user/isUser/' + account)
-      .then(res =>
-        walletService.signMessage(message).then(signedMessage =>
-          axios
-            .post(url + 'user/' + (res.data === true ? 'auth' : 'register'), {
-              signedMessage,
-              message,
-              walletAddress: account,
-            })
-            .then(res => {
-              if (res.data && res.data.token) {
-                dispatch(
-                  actions.setNotificationToken({
-                    token: res.data.token,
-                    wallet: account,
-                  }),
-                );
-              }
-            }),
-        ),
-      )
+    const { data: alreadyUser } = await axios.get(
+      url + 'user/isUser/' + account,
+    );
+    walletService
+      .signMessage(message)
+      .then(signedMessage => {
+        axios
+          .post(url + 'user/' + (alreadyUser ? 'auth' : 'register'), {
+            signedMessage,
+            message,
+            walletAddress: account,
+          })
+          .then(res => {
+            if (res.data && res.data.token) {
+              dispatch(
+                actions.setNotificationToken({
+                  token: res.data.token,
+                  wallet: account,
+                }),
+              );
+            }
+          })
+          .catch(error => {
+            console.error(error);
+            onClose();
+          });
+      })
       .catch(error => {
         console.error(error);
         onClose();

--- a/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
@@ -82,10 +82,10 @@ export const NotificationSettingsDialog: React.FC<INotificationSettingsDialogPro
     const message = `Login to backend on: ${timestamp}`;
     return axios
       .get(url + 'user/isUser/' + account)
-      .then(alreadyUser =>
+      .then(res =>
         walletService.signMessage(message).then(signedMessage =>
           axios
-            .post(url + 'user/' + (alreadyUser ? 'auth' : 'register'), {
+            .post(url + 'user/' + (res.data === true ? 'auth' : 'register'), {
               signedMessage,
               message,
               walletAddress: account,


### PR DESCRIPTION
This should fix the issue with notification authentication on the frontend.

The existing version uses the full response instead of response.data, and so is always calling the /auth endpoint instead of /register for new users

Resolves https://sovryn.atlassian.net/browse/SOV-970