### PR TITLE
Fix/notification auth failing/sov 970

### DIFF
--- a/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
@@ -80,28 +80,33 @@ export const NotificationSettingsDialog: React.FC<INotificationSettingsDialogPro
     if (!account) return;
     const timestamp = new Date();
     const message = `Login to backend on: ${timestamp}`;
-    return axios
-      .get(url + 'user/isUser/' + account)
-      .then(res =>
-        walletService.signMessage(message).then(signedMessage =>
-          axios
-            .post(url + 'user/' + (res.data === true ? 'auth' : 'register'), {
-              signedMessage,
-              message,
-              walletAddress: account,
-            })
-            .then(res => {
-              if (res.data && res.data.token) {
-                dispatch(
-                  actions.setNotificationToken({
-                    token: res.data.token,
-                    wallet: account,
-                  }),
-                );
-              }
-            }),
-        ),
-      )
+    const { data: alreadyUser } = await axios.get(
+      url + 'user/isUser/' + account,
+    );
+    walletService
+      .signMessage(message)
+      .then(signedMessage => {
+        axios
+          .post(url + 'user/' + (alreadyUser ? 'auth' : 'register'), {
+            signedMessage,
+            message,
+            walletAddress: account,
+          })
+          .then(res => {
+            if (res.data && res.data.token) {
+              dispatch(
+                actions.setNotificationToken({
+                  token: res.data.token,
+                  wallet: account,
+                }),
+              );
+            }
+          })
+          .catch(error => {
+            console.error(error);
+            onClose();
+          });
+      })
       .catch(error => {
         console.error(error);
         onClose();

--- a/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
+++ b/src/app/pages/MarginTradePage/components/NotificationSettingsDialog/index.tsx
@@ -82,10 +82,10 @@ export const NotificationSettingsDialog: React.FC<INotificationSettingsDialogPro
     const message = `Login to backend on: ${timestamp}`;
     return axios
       .get(url + 'user/isUser/' + account)
-      .then(alreadyUser =>
+      .then(res =>
         walletService.signMessage(message).then(signedMessage =>
           axios
-            .post(url + 'user/' + (alreadyUser ? 'auth' : 'register'), {
+            .post(url + 'user/' + (res.data === true ? 'auth' : 'register'), {
               signedMessage,
               message,
               walletAddress: account,


### PR DESCRIPTION
Reverted breaking changes from this commit: https://github.com/DistributedCollective/Sovryn-frontend/commit/c3321f11d75a323d671fd080aae52d6be4a4de17

New users can now sign up for notifications.

There is still a bug where the notification sign-up only works on the margin trade page (this is a separate bug)

Resolves https://sovryn.atlassian.net/browse/SOV-970