### PR TITLE
SOV-1954: Pair Selector price change issue

### DIFF
--- a/src/app/components/PairNavbar/utils.ts
+++ b/src/app/components/PairNavbar/utils.ts
@@ -1,3 +1,4 @@
+import { bignumber } from 'mathjs';
 import { IPairData } from 'types/trading-pairs';
 
 export const getLastPrice = (
@@ -49,29 +50,29 @@ export const getPercent = (
   pair1: IPairData,
   RBTC_source: string,
 ) => {
-  const lastPrice = getLastPrice(pair0, pair1, RBTC_source);
-  const dayPrice = getDayPrice(pair0, pair1, RBTC_source);
-
-  //generating dayPrice for all pairs
-  let percent = 0;
-  //for pairs without RBTC
-  if (pair1 !== pair0) {
-    if (lastPrice > dayPrice) {
-      percent = ((lastPrice - dayPrice) / dayPrice) * 100;
-    } else if (lastPrice < dayPrice) {
-      percent = ((lastPrice - dayPrice) / lastPrice) * 100;
-    }
-  }
-  //for pairs with RBTC as source
+  // //for pairs with RBTC as source
   if (RBTC_source) {
-    percent =
-      pair0.price_change_percent_24h !== 0
-        ? -pair0.price_change_percent_24h
-        : pair0.price_change_percent_24h;
+    const percent = bignumber(0).minus(pair0.price_change_percent_24h);
+    return percent.toFixed(18);
   }
-  //for pairs with RBTC as target
+
+  // //for pairs with RBTC as target
   if (pair0.base_symbol === pair1.base_symbol && !RBTC_source) {
-    percent = pair0.price_change_percent_24h;
+    const percent = pair0.price_change_percent_24h;
+    return percent;
   }
-  return percent;
+
+  if (pair1 !== pair0) {
+    console.debug('PAIR 1', pair1);
+    console.debug('PAIR 0', pair0);
+    const lastPrice = bignumber(pair0.last_price).div(
+      bignumber(pair1.last_price),
+    );
+    const dayPrice = bignumber(pair0.day_price).div(bignumber(pair1.day_price));
+    const diff = lastPrice.minus(dayPrice);
+    const percent = diff.div(dayPrice).mul(100);
+    return parseFloat(percent.toFixed(18));
+  }
+
+  return 0;
 };

--- a/src/app/components/PairNavbar/utils.ts
+++ b/src/app/components/PairNavbar/utils.ts
@@ -1,6 +1,17 @@
 import { bignumber } from 'mathjs';
 import { IPairData } from 'types/trading-pairs';
 
+export const getPercentageChange = (
+  currentPrice: number,
+  prevPrice: number,
+) => {
+  const diff = currentPrice - prevPrice;
+  if (diff === 0) {
+    return 0;
+  }
+  return (diff / prevPrice) * 100;
+};
+
 export const getLastPrice = (
   pair0: IPairData,
   pair1: IPairData,
@@ -23,28 +34,6 @@ export const getLastPrice = (
   return lastPrice;
 };
 
-export const getDayPrice = (
-  pair0: IPairData,
-  pair1: IPairData,
-  RBTC_source: string,
-) => {
-  //generating dayPrice for all pairs
-  let dayPrice = 0;
-  //for pairs without RBTC
-  if (pair1 !== pair0) {
-    dayPrice = pair0.day_price / pair1.day_price;
-  }
-  //for pairs with RBTC as source
-  if (RBTC_source) {
-    dayPrice = 1 / pair0.day_price;
-  }
-  //for pairs with RBTC as target
-  if (pair0.base_symbol === pair1.base_symbol && !RBTC_source) {
-    dayPrice = pair0.day_price;
-  }
-  return dayPrice;
-};
-
 export const getPercent = (
   pair0: IPairData,
   pair1: IPairData,
@@ -56,21 +45,18 @@ export const getPercent = (
     return percent.toFixed(18);
   }
 
-  // //for pairs with RBTC as target
+  // for pairs with RBTC as target
   if (pair0.base_symbol === pair1.base_symbol && !RBTC_source) {
     const percent = pair0.price_change_percent_24h;
     return percent;
   }
 
   if (pair1 !== pair0) {
-    console.debug('PAIR 1', pair1);
-    console.debug('PAIR 0', pair0);
     const lastPrice = bignumber(pair0.last_price).div(
       bignumber(pair1.last_price),
     );
     const dayPrice = bignumber(pair0.day_price).div(bignumber(pair1.day_price));
-    const diff = lastPrice.minus(dayPrice);
-    const percent = diff.div(dayPrice).mul(100);
+    const percent = getPercentageChange(Number(lastPrice), Number(dayPrice));
     return parseFloat(percent.toFixed(18));
   }
 

--- a/src/app/components/PairNavbarInfo/index.tsx
+++ b/src/app/components/PairNavbarInfo/index.tsx
@@ -26,7 +26,7 @@ const parsePairData = (
   let highPrice = 0;
   let lowPrice = 0;
 
-  /** Special case for RBTC/XUSD pair */
+  /** Special case for RBTC/XUSD pair - underlying AMM pool is XUSD/RBTC but we need to display the reverse */
   if (
     pairData[0].trading_pairs === pairData[1].trading_pairs &&
     pairData[1].base_symbol === Asset.XUSD

--- a/src/app/components/PairNavbarInfo/index.tsx
+++ b/src/app/components/PairNavbarInfo/index.tsx
@@ -6,18 +6,12 @@ import { ITradingPairs } from 'types/trading-pairs';
 import classNames from 'classnames';
 import { watchPrice } from 'utils/pair-price-tracker';
 import { Asset } from 'types';
+import { getPercentageChange } from '../PairNavbar/utils';
+import { bignumber } from 'mathjs';
 
 interface IPairNavbarInfoProps {
   pair: ITradingPairs;
 }
-
-const getPercentageChange = (currentPrice: number, prevPrice: number) => {
-  const diff = currentPrice - prevPrice;
-  if (diff === 0) {
-    return 0;
-  }
-  return (diff / prevPrice) * 100;
-};
 
 const parsePairData = (
   pairData: ITradingPairs,
@@ -31,30 +25,42 @@ const parsePairData = (
   let percentageChange = 0;
   let highPrice = 0;
   let lowPrice = 0;
+
+  /** Special case for RBTC/XUSD pair */
+  if (
+    pairData[0].trading_pairs === pairData[1].trading_pairs &&
+    pairData[1].base_symbol === Asset.XUSD
+  ) {
+    lastPrice = pairData[0].last_price;
+    percentageChange = -pairData[0].price_change_percent_24h;
+    lowPrice = Number(bignumber(1).div(pairData[0].high_price_24h).toFixed(18));
+    highPrice = Number(bignumber(1).div(pairData[0].lowest_price_24h));
+    return { highPrice, lowPrice, percentageChange, lastPrice };
+  }
+
   /** BTC is quote symbol */
   if (pairData[0].trading_pairs === pairData[1].trading_pairs) {
     lastPrice = pairData[0].last_price;
     percentageChange = pairData[0].price_change_percent_24h;
     highPrice = pairData[0].high_price_24h;
     lowPrice = pairData[0].lowest_price_24h;
-  } else {
-    lastPrice = pairData[0].last_price * (1 / pairData[1].last_price);
-    percentageChange = getPercentageChange(
-      lastPrice,
-      pairData[0].day_price * (1 / pairData[1].day_price),
-    );
-    if (pairData[1].base_symbol === Asset.XUSD) {
-      highPrice = pairData[0].high_price_24h_usd;
-      lowPrice = pairData[0].lowest_price_24h_usd;
-    }
+    return { highPrice, lowPrice, percentageChange, lastPrice };
   }
 
-  return {
+  lastPrice = pairData[0].last_price * (1 / pairData[1].last_price);
+  percentageChange = getPercentageChange(
     lastPrice,
-    percentageChange,
-    highPrice,
-    lowPrice,
-  };
+    pairData[0].day_price * (1 / pairData[1].day_price),
+  );
+
+  /** XUSD is quote symbol */
+  if (pairData[1].base_symbol === Asset.XUSD) {
+    highPrice = pairData[0].high_price_24h_usd;
+    lowPrice = pairData[0].lowest_price_24h_usd;
+    return { highPrice, lowPrice, percentageChange, lastPrice };
+  }
+
+  return { highPrice, lowPrice, percentageChange, lastPrice };
 };
 
 export const PairNavbarInfo: React.FC<IPairNavbarInfoProps> = ({ pair }) => {


### PR DESCRIPTION
Hotfix for the issue where the pair navbar dropdown menu shows the wrong 24h % change. 

Also fix for another issue I spotted where the percentage change is signed wrong for the RBTC/XUSD pair (eg if the change is 1% it will show -1%). @soulBit let's maybe discuss this?

https://sovryn.atlassian.net/browse/SOV-1954